### PR TITLE
Github Topic Scraper added

### DIFF
--- a/GitHub Topic Scraper/Github_Repo_Topics_Scraper.ipynb
+++ b/GitHub Topic Scraper/Github_Repo_Topics_Scraper.ipynb
@@ -1,0 +1,326 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CbuhFtGC765W"
+      },
+      "source": [
+        "## Scrape the list of topics from Github "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "id": "7oMzpiGm6_bw"
+      },
+      "outputs": [],
+      "source": [
+        "import requests\n",
+        "from bs4 import BeautifulSoup\n",
+        "import pandas as pd\n",
+        "\n",
+        "\n",
+        "def get_topics_page():\n",
+        "    # TODO - add comments\n",
+        "    topics_url = 'https://github.com/topics'\n",
+        "    response = requests.get(topics_url)\n",
+        "    if response.status_code != 200:\n",
+        "        raise Exception('Failed to load page {}'.format(topic_url))\n",
+        "    doc = BeautifulSoup(response.text, 'html.parser')\n",
+        "    return doc"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "id": "mbXNM7jS7MAW"
+      },
+      "outputs": [],
+      "source": [
+        "doc = get_topics_page()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "id": "oddZ1eIJ7Pg5"
+      },
+      "outputs": [],
+      "source": [
+        "def get_topic_titles(doc):\n",
+        "    selection_class = 'f3 lh-condensed mb-0 mt-1 Link--primary'\n",
+        "    topic_title_tags = doc.find_all('p', {'class': selection_class})\n",
+        "    topic_titles = []\n",
+        "    for tag in topic_title_tags:\n",
+        "        topic_titles.append(tag.text)\n",
+        "    return topic_titles"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "id": "DlDaGotd7UmY"
+      },
+      "outputs": [],
+      "source": [
+        "titles = get_topic_titles(doc)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_Fxs7ff27Xtu",
+        "outputId": "9b9f48de-84cc-4a92-b764-dd489a5afae6"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "30"
+            ]
+          },
+          "execution_count": 21,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "len(titles)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "xGwbsGyU7e1B",
+        "outputId": "daf80058-32b0-467b-bf4c-a4f46b6402f8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['3D', 'Ajax', 'Algorithm', 'Amp', 'Android']"
+            ]
+          },
+          "execution_count": 22,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "titles[:5]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "id": "pN_AqSWo7h-c"
+      },
+      "outputs": [],
+      "source": [
+        "def get_topic_descs(doc):\n",
+        "    desc_selector = 'f5 color-text-secondary mb-0 mt-1'\n",
+        "    topic_desc_tags = doc.find_all('p', {'class': desc_selector})\n",
+        "    topic_descs = []\n",
+        "    for tag in topic_desc_tags:\n",
+        "        topic_descs.append(tag.text.strip())\n",
+        "    return topic_descs\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "id": "vcZeXyXy7h_N"
+      },
+      "outputs": [],
+      "source": [
+        "def get_topic_urls(doc):\n",
+        "    topic_link_tags = doc.find_all('a', {'class': 'd-flex no-underline'})\n",
+        "    topic_urls = []\n",
+        "    base_url = 'https://github.com'\n",
+        "    for tag in topic_link_tags:\n",
+        "        topic_urls.append(base_url + tag['href'])\n",
+        "    return topic_urls"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "id": "NluymPjL7iHc"
+      },
+      "outputs": [],
+      "source": [
+        "def scrape_topics():\n",
+        "    topics_url = 'https://github.com/topics'\n",
+        "    response = requests.get(topics_url)\n",
+        "    if response.status_code != 200:\n",
+        "        raise Exception('Failed to load page {}'.format(topic_url))\n",
+        "    doc = BeautifulSoup(response.text, 'html.parser')\n",
+        "    topics_dict = {\n",
+        "        'title': get_topic_titles(doc),\n",
+        "        'description': get_topic_descs(doc),\n",
+        "        'url': get_topic_urls(doc)\n",
+        "    }\n",
+        "    return pd.DataFrame(topics_dict)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eU0ei1dT70L1"
+      },
+      "source": [
+        "## Get the top 25 repositories from a topic page"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "id": "B8zHWmFq8MVc"
+      },
+      "outputs": [],
+      "source": [
+        "def get_topic_page(topic_url):\n",
+        "    # Download the page\n",
+        "    response = requests.get(topic_url)\n",
+        "    # Check successful response\n",
+        "    if response.status_code != 200:\n",
+        "        raise Exception('Failed to load page {}'.format(topic_url))\n",
+        "    # Parse using Beautiful soup\n",
+        "    topic_doc = BeautifulSoup(response.text, 'html.parser')\n",
+        "    return topic_doc"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "id": "J_6FSRwQ8SLe"
+      },
+      "outputs": [],
+      "source": [
+        "doc = get_topic_page('https://github.com/topics/3d')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "id": "SsB3NVj38T14"
+      },
+      "outputs": [],
+      "source": [
+        "def get_repo_info(h1_tag, star_tag):\n",
+        "    # returns all the required info about a repository\n",
+        "    a_tags = h1_tag.find_all('a')\n",
+        "    username = a_tags[0].text.strip()\n",
+        "    repo_name = a_tags[1].text.strip()\n",
+        "    repo_url =  base_url + a_tags[1]['href']\n",
+        "    stars = parse_star_count(star_tag.text.strip())\n",
+        "    return username, repo_name, stars, repo_url"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "id": "mwjBGfKb8W6w"
+      },
+      "outputs": [],
+      "source": [
+        "def get_topic_repos(topic_doc):\n",
+        "    # Get the h1 tags containing repo title, repo URL and username\n",
+        "    h1_selection_class = 'f3 color-text-secondary text-normal lh-condensed'\n",
+        "    repo_tags = topic_doc.find_all('h1', {'class': h1_selection_class} )\n",
+        "    # Get star tags\n",
+        "    star_tags = topic_doc.find_all('a', { 'class': 'social-count float-none'})\n",
+        "    \n",
+        "    topic_repos_dict = { 'username': [], 'repo_name': [], 'stars': [],'repo_url': []}\n",
+        "\n",
+        "    # Get repo info\n",
+        "    for i in range(len(repo_tags)):\n",
+        "        repo_info = get_repo_info(repo_tags[i], star_tags[i])\n",
+        "        topic_repos_dict['username'].append(repo_info[0])\n",
+        "        topic_repos_dict['repo_name'].append(repo_info[1])\n",
+        "        topic_repos_dict['stars'].append(repo_info[2])\n",
+        "        topic_repos_dict['repo_url'].append(repo_info[3])\n",
+        "        \n",
+        "    return pd.DataFrame(topic_repos_dict)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {
+        "id": "tG6qle3G8puU"
+      },
+      "outputs": [],
+      "source": [
+        "def scrape_topic(topic_url, path):\n",
+        "    if os.path.exists(path):\n",
+        "        print(\"The file {} already exists. Skipping...\".format(path))\n",
+        "        return\n",
+        "    topic_df = get_topic_repos(get_topic_page(topic_url))\n",
+        "    topic_df.to_csv(path, index=None)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vmCnMv6X8wks"
+      },
+      "source": [
+        "## Final Function"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "metadata": {
+        "id": "c-MOikvE812I"
+      },
+      "outputs": [],
+      "source": [
+        "def scrape_topics_repos():\n",
+        "    print('Scraping list of topics')\n",
+        "    topics_df = scrape_topics()\n",
+        "    \n",
+        "    os.makedirs('data', exist_ok=True)\n",
+        "    for index, row in topics_df.iterrows():\n",
+        "        print('Scraping top repositories for \"{}\"'.format(row['title']))\n",
+        "        scrape_topic(row['url'], 'data/{}.csv'.format(row['title']))"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "Github-Repo-Topics-Scraper.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/GitHub Topic Scraper/README.md
+++ b/GitHub Topic Scraper/README.md
@@ -1,0 +1,21 @@
+# Github-Repo-Topics-Scraper
+This is web scraping project for Github Topics.
+According to me it would be really helpful and beneficial for developers who are starting out to get data of different github repositories based on different topics.
+
+### Libraries used: 
+- requests
+- beautifulsoup
+- pandas
+
+### Features of this Web Scraper:
+1. It's going to scrape https://github.com/topics 
+2. It'll get a list of topics. For each topic, we'll get topic title, topic page URL and topic description. 
+3. For each topic, it'll get the top 25 repositories in the topic from the topic page.
+4. For each repository, it'll grab the repo name, username, stars and repo URL.
+5. For each topic it'll create a CSV file in the following format:
+
+```
+Repo Name,Username,Stars,Repo URL
+three.js,mrdoob,69700,https://github.com/mrdoob/three.js
+libgdx,libgdx,18300,https://github.com/libgdx/libgdx
+```

--- a/GitHub Topic Scraper/requirements.txt
+++ b/GitHub Topic Scraper/requirements.txt
@@ -1,0 +1,3 @@
+ requests
+ BeautifulSoup
+ pandas


### PR DESCRIPTION
Issue #422 

### Description of the Project:
This is web scraping project According to me it would be really helpful and beneficial for developers who are starting out to get data of different github repositories based on different topics.

### What it does:
- It's going to scrape https://github.com/topics.
-  It'll get a list of topics. For each topic, we'll get the topic title, topic page URL and topic description.

### Approach followed:
1. Scrape the list of topics from the page.
2. Scrape the top repo lists from the chosen topic page.