### PR TITLE
Doc: Revise issue templates, add contributor checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,45 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
+Title: Project Title
+About: Create a report to help us improve.
+Name: YourName
+Label: Bug Report
+Assignee: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+Define You:
 
-**To Reproduce**
+- [ ] LGM-SOC'21 Participant 
+- [ ] Contributor
+
+
+<!-- Have you talked to any of the Moderators or Project Admin (Prathima Kadari) before creating this issue? If not, just have a quick discussion and then once approved, create this issue. -->
+
+**Describe the Bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**Steps to Reproduce**
+
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+1. 
+2. 
+3. 
+4. 
+
+**Expected Behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Actual Behavior**
+
+<!-- A clear and concise description of how the code performed w.r.t expectations. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Additional Details**
 
-**Additional context**
-Add any other context about the problem here.
+<!-- Write some additional details if you can, which might help to debug the issue quicker. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,36 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
+Title: Project Title
+About: Suggest an idea for this project
+Name: YourName
+Label: Feature Request
+Assignee: ''
 
 ---
 
+Define You:
+
+- [ ] LGM-SOC'21 Participant 
+- [ ] Contributor
+
+
+<!-- Have you talked to any of the Moderators or Project Admin (Prathima Kadari) before creating this issue? If not, just have a quick discussion and then once approved, create this feature request. -->
+
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what the problem is. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe the solution you'd like...**
+
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered?**
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Approach to be followed (optional):**
+
+<!-- A clear and concise description of approach to be followed. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
Standardize and expand the bug_report and feature_request templates. Frontmatter fields were adjusted and populated with placeholders (Title, About, Name, Label, Assignee). Added a "Define You" checklist for contributors (LGM-SOC'21 Participant / Contributor), guidance to contact project moderators (mentions Prathima Kadari), and clearer sections for Describe Bug/Expected/Actual/Steps/Additional Details. Removed some platform-specific fields and replaced inline prompts with HTML comments to improve clarity and streamline issue submission.


I am participating under GSSOC-26 so can u assign me under it and any labels  accordingly.