### PR TITLE
Add Audio Deepfake Detection using MFCC + LSTM

### DIFF
--- a/Audio_Deepfake_Detection/Audio_Deepfake_Detection.ipynb
+++ b/Audio_Deepfake_Detection/Audio_Deepfake_Detection.ipynb
@@ -1,0 +1,420 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import files\n",
+        "files.upload()"
+      ],
+      "metadata": {
+        "id": "WW0d4P5dsW5B"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!mkdir -p ~/.kaggle\n",
+        "!cp kaggle.json ~/.kaggle/\n",
+        "!chmod 600 ~/.kaggle/kaggle.json"
+      ],
+      "metadata": {
+        "id": "BnTMlKXSsayx"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!kaggle datasets download -d anishsarkar22/asvpoof-2019-dataset-la\n",
+        "!unzip asvpoof-2019-dataset-la.zip"
+      ],
+      "metadata": {
+        "id": "3l7T0D2msb7w"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "import numpy as np\n",
+        "import librosa\n",
+        "import pandas as pd\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.preprocessing import LabelEncoder\n",
+        "import tensorflow as tf\n",
+        "from tensorflow.keras.models import Sequential\n",
+        "from tensorflow.keras.layers import LSTM, Dense, Dropout\n",
+        "import matplotlib.pyplot as plt\n",
+        "import seaborn as sns\n",
+        "from sklearn.metrics import classification_report, confusion_matrix\n",
+        "\n",
+        "print(\"All libraries imported successfully\")"
+      ],
+      "metadata": {
+        "id": "cSDMmTqMtzbj"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "train_protocol = pd.read_csv(\n",
+        "    'LA/ASVspoof2019_LA_cm_protocols/ASVspoof2019.LA.cm.train.trn.txt',\n",
+        "    sep=' ', header=None,\n",
+        "    names=['speaker', 'file', 'env', 'attack', 'label']\n",
+        ")\n",
+        "\n",
+        "print(train_protocol.head())\n",
+        "print(train_protocol['label'].value_counts())"
+      ],
+      "metadata": {
+        "id": "r07zrt7pt9fq"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def extract_mfcc(file_path, n_mfcc=40, max_len=200):\n",
+        "    try:\n",
+        "        audio, sr = librosa.load(file_path, sr=16000)\n",
+        "        mfcc = librosa.feature.mfcc(y=audio, sr=sr, n_mfcc=n_mfcc)\n",
+        "        if mfcc.shape[1] < max_len:\n",
+        "            mfcc = np.pad(mfcc, ((0,0),(0, max_len - mfcc.shape[1])))\n",
+        "        else:\n",
+        "            mfcc = mfcc[:, :max_len]\n",
+        "        return mfcc.T\n",
+        "    except:\n",
+        "        return None\n",
+        "\n",
+        "# Use subset for speed (full dataset = very slow on Colab)\n",
+        "subset = train_protocol.sample(n=2000, random_state=42)\n",
+        "print(subset['label'].value_counts())"
+      ],
+      "metadata": {
+        "id": "oZdPFZj_uD4x"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "X, y = [], []\n",
+        "train_audio_path = 'LA/ASVspoof2019_LA_train/flac/'\n",
+        "\n",
+        "for _, row in subset.iterrows():\n",
+        "    path = os.path.join(train_audio_path, row['file'] + '.flac')\n",
+        "    mfcc = extract_mfcc(path)\n",
+        "    if mfcc is not None:\n",
+        "        X.append(mfcc)\n",
+        "        y.append(row['label'])\n",
+        "\n",
+        "X = np.array(X)\n",
+        "y = np.array(y)\n",
+        "print(f\"X shape: {X.shape}, y shape: {y.shape}\")"
+      ],
+      "metadata": {
+        "id": "KVemBzqauJjR"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Encode labels\n",
+        "le = LabelEncoder()\n",
+        "y_encoded = le.fit_transform(y)\n",
+        "\n",
+        "# Train-test split\n",
+        "X_train, X_test, y_train, y_test = train_test_split(\n",
+        "    X, y_encoded, test_size=0.2, random_state=42, stratify=y_encoded\n",
+        ")\n",
+        "\n",
+        "print(f\"Train: {X_train.shape}, Test: {X_test.shape}\")\n",
+        "print(f\"Classes: {le.classes_}\")"
+      ],
+      "metadata": {
+        "id": "-Lrhumx_ufFp"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = Sequential([\n",
+        "    LSTM(128, input_shape=(200, 40), return_sequences=True),\n",
+        "    Dropout(0.3),\n",
+        "    LSTM(64),\n",
+        "    Dropout(0.3),\n",
+        "    Dense(32, activation='relu'),\n",
+        "    Dense(1, activation='sigmoid')\n",
+        "])\n",
+        "\n",
+        "model.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+        "model.summary()"
+      ],
+      "metadata": {
+        "id": "RGZp1U10uk-x"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "history = model.fit(\n",
+        "    X_train, y_train,\n",
+        "    epochs=10,\n",
+        "    batch_size=32,\n",
+        "    validation_data=(X_test, y_test),\n",
+        "    verbose=1\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "RI_imp0pupWr"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "fig, axes = plt.subplots(1, 2, figsize=(12, 4))\n",
+        "\n",
+        "axes[0].plot(history.history['accuracy'], label='Train')\n",
+        "axes[0].plot(history.history['val_accuracy'], label='Validation')\n",
+        "axes[0].set_title('Model Accuracy')\n",
+        "axes[0].legend()\n",
+        "\n",
+        "axes[1].plot(history.history['loss'], label='Train')\n",
+        "axes[1].plot(history.history['val_loss'], label='Validation')\n",
+        "axes[1].set_title('Model Loss')\n",
+        "axes[1].legend()\n",
+        "\n",
+        "plt.tight_layout()\n",
+        "plt.savefig('training_history.png', dpi=150)\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "MckYaUSyveMV"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Evaluation\n",
+        "y_pred = (model.predict(X_test) > 0.5).astype(int).flatten()\n",
+        "\n",
+        "print(classification_report(y_test, y_pred, target_names=le.classes_))\n",
+        "\n",
+        "# Confusion Matrix\n",
+        "cm = confusion_matrix(y_test, y_pred)\n",
+        "plt.figure(figsize=(6, 5))\n",
+        "sns.heatmap(cm, annot=True, fmt='d', cmap='Blues',\n",
+        "            xticklabels=le.classes_, yticklabels=le.classes_)\n",
+        "plt.title('Confusion Matrix')\n",
+        "plt.ylabel('Actual')\n",
+        "plt.xlabel('Predicted')\n",
+        "plt.savefig('confusion_matrix.png', dpi=150)\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "ZX2YrHZBvpQe"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from sklearn.utils.class_weight import compute_class_weight\n",
+        "\n",
+        "# Compute class weights\n",
+        "class_weights = compute_class_weight('balanced', classes=np.unique(y_train), y=y_train)\n",
+        "class_weight_dict = dict(enumerate(class_weights))\n",
+        "print(\"Class weights:\", class_weight_dict)\n",
+        "\n",
+        "# Rebuild model\n",
+        "model2 = Sequential([\n",
+        "    tf.keras.layers.Input(shape=(200, 40)),\n",
+        "    LSTM(128, return_sequences=True),\n",
+        "    Dropout(0.3),\n",
+        "    LSTM(64),\n",
+        "    Dropout(0.3),\n",
+        "    Dense(32, activation='relu'),\n",
+        "    Dense(1, activation='sigmoid')\n",
+        "])\n",
+        "\n",
+        "model2.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+        "\n",
+        "history2 = model2.fit(\n",
+        "    X_train, y_train,\n",
+        "    epochs=15,\n",
+        "    batch_size=32,\n",
+        "    validation_data=(X_test, y_test),\n",
+        "    class_weight=class_weight_dict,\n",
+        "    verbose=1\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "zJJjCd4Lv1IC"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "bonafide_df = train_protocol[train_protocol['label'] == 'bonafide']\n",
+        "spoof_df = train_protocol[train_protocol['label'] == 'spoof'].sample(n=len(bonafide_df), random_state=42)\n",
+        "balanced_df = pd.concat([bonafide_df, spoof_df]).sample(frac=1, random_state=42)\n",
+        "\n",
+        "print(balanced_df['label'].value_counts())"
+      ],
+      "metadata": {
+        "id": "vkZQpEHNxFHi"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "X2, y2 = [], []\n",
+        "\n",
+        "for _, row in balanced_df.iterrows():\n",
+        "    path = os.path.join(train_audio_path, row['file'] + '.flac')\n",
+        "    mfcc = extract_mfcc(path)\n",
+        "    if mfcc is not None:\n",
+        "        X2.append(mfcc)\n",
+        "        y2.append(row['label'])\n",
+        "\n",
+        "X2 = np.array(X2)\n",
+        "y2 = np.array(y2)\n",
+        "print(f\"X2 shape: {X2.shape}, y2 shape: {y2.shape}\")"
+      ],
+      "metadata": {
+        "id": "3fn7DiotxI16"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "le2 = LabelEncoder()\n",
+        "y2_encoded = le2.fit_transform(y2)\n",
+        "\n",
+        "X2_train, X2_test, y2_train, y2_test = train_test_split(\n",
+        "    X2, y2_encoded, test_size=0.2, random_state=42, stratify=y2_encoded\n",
+        ")\n",
+        "\n",
+        "model3 = Sequential([\n",
+        "    tf.keras.layers.Input(shape=(200, 40)),\n",
+        "    LSTM(128, return_sequences=True),\n",
+        "    Dropout(0.3),\n",
+        "    LSTM(64),\n",
+        "    Dropout(0.3),\n",
+        "    Dense(32, activation='relu'),\n",
+        "    Dense(1, activation='sigmoid')\n",
+        "])\n",
+        "\n",
+        "model3.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+        "\n",
+        "history3 = model3.fit(\n",
+        "    X2_train, y2_train,\n",
+        "    epochs=15,\n",
+        "    batch_size=32,\n",
+        "    validation_data=(X2_test, y2_test),\n",
+        "    verbose=1\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "14BoeGCWxk_E"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "y2_pred = (model3.predict(X2_test) > 0.5).astype(int).flatten()\n",
+        "\n",
+        "print(classification_report(y2_test, y2_pred, target_names=le2.classes_))\n",
+        "\n",
+        "cm2 = confusion_matrix(y2_test, y2_pred)\n",
+        "plt.figure(figsize=(6, 5))\n",
+        "sns.heatmap(cm2, annot=True, fmt='d', cmap='Blues',\n",
+        "            xticklabels=le2.classes_, yticklabels=le2.classes_)\n",
+        "plt.title('Confusion Matrix - Balanced Model')\n",
+        "plt.ylabel('Actual')\n",
+        "plt.xlabel('Predicted')\n",
+        "plt.savefig('confusion_matrix_balanced.png', dpi=150)\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "J3qyHfBI1O7L"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Save model !!\n",
+        "model3.save('audio_deepfake_detector.h5')\n",
+        "print(\"Model saved.\")\n",
+        "\n",
+        "# Final training plot\n",
+        "fig, axes = plt.subplots(1, 2, figsize=(12, 4))\n",
+        "\n",
+        "axes[0].plot(history3.history['accuracy'], label='Train')\n",
+        "axes[0].plot(history3.history['val_accuracy'], label='Validation')\n",
+        "axes[0].set_title('Model Accuracy (Balanced)')\n",
+        "axes[0].set_xlabel('Epoch')\n",
+        "axes[0].legend()\n",
+        "\n",
+        "axes[1].plot(history3.history['loss'], label='Train')\n",
+        "axes[1].plot(history3.history['val_loss'], label='Validation')\n",
+        "axes[1].set_title('Model Loss (Balanced)')\n",
+        "axes[1].set_xlabel('Epoch')\n",
+        "axes[1].legend()\n",
+        "\n",
+        "plt.tight_layout()\n",
+        "plt.savefig('training_history_balanced.png', dpi=150)\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "qL6Qp4qV1zgL"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/Audio_Deepfake_Detection/README.md
+++ b/Audio_Deepfake_Detection/README.md
@@ -1,0 +1,48 @@
+<img height="27" src="https://img.shields.io/badge/Audio_Deepfake_Detection-Advanced-darkred.svg?&style=for-the-badge&logo=tensorflow&logoColor=white"/>
+<br>
+
+![](https://img.shields.io/badge/Language-Python-blue.svg)
+![](https://img.shields.io/badge/Framework-TensorFlow-orange.svg)
+![](https://img.shields.io/badge/Status-Complete-brightgreen.svg)
+![](https://img.shields.io/badge/Dataset-ASVspoof_2019-lightgrey.svg)
+
+# Audio Deepfake Detection
+
+## Why This Matters
+Voice cloning and AI-generated speech are being weaponized for fraud, impersonation, and misinformation. Most deepfake detection work focuses on images and video audio is often overlooked. This project tackles that gap directly.
+
+## What It Does
+Classifies audio clips as **real (bonafide)** or **AI-generated (spoof)** using MFCC-based feature extraction and an LSTM deep learning model trained on the ASVspoof 2019 dataset.
+
+## Pipeline
+Raw Audio (.flac)
+↓
+MFCC Extraction (40 coefficients × 200 timesteps)
+↓
+LSTM Model (128 → 64 un
+
+## Results
+
+| Class | Precision | Recall | F1-Score |
+|-------|-----------|--------|----------|
+| Bonafide | 0.85 | 0.92 | 0.88 |
+| Spoof | 0.91 | 0.84 | 0.88 |
+
+**Overall Accuracy: 88%**
+
+## Tech Stack
+- TensorFlow / Keras — model training
+- librosa — audio feature extraction
+- scikit-learn — evaluation metrics
+- ASVspoof 2019 LA — dataset
+
+## Run It
+1. Download dataset from [Kaggle](https://www.kaggle.com/datasets/anishsarkar22/asvpoof-2019-dataset-la)
+2. Open `Audio_Deepfake_Detection.ipynb` in Google Colab
+3. Run all cells
+
+[<img height="30" src="https://img.shields.io/badge/linkedin-blue.svg?&style=for-the-badge&logo=linkedin&logoColor=white" />][LinkedIn]
+[<img height="30" src="https://img.shields.io/badge/github-black.svg?&style=for-the-badge&logo=github&logoColor=white" />][Github]
+
+[linkedin]: https://www.linkedin.com/in/siddharthmac/
+[github]: https://github.com/SiddharthRiot/


### PR DESCRIPTION
Adds a new project focused on detecting AI-generated (spoofed) audio from real speech, which is a largely overlooked area compared to image and video deepfake detection.

- Dataset: ASVspoof 2019 LA with balanced sampling of 2580 bonafide and 2580 spoof samples
- MFCC features (40 coefficients, 200 timesteps) extracted using librosa
- LSTM-based deep learning model trained from scratch
- Achieved 88% accuracy on balanced test set
- Includes notebook and README

Closes #1337