### PR TITLE
[BUG] Fix :Add comprehensive .gitignore to prevent tracking of auto-generated files (#1375)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,176 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+ 
+# C extensions
+*.so
+ 
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+ 
+# PyInstaller
+*.manifest
+*.spec
+ 
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+ 
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+ 
+# Translations
+*.mo
+*.pot
+ 
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+ 
+# Flask stuff:
+instance/
+.webassets-cache
+ 
+# Scrapy stuff:
+.scrapy
+ 
+# Sphinx documentation
+docs/_build/
+ 
+# PyBuilder
+target/
+ 
+# Jupyter Notebook
+.ipynb_checkpoints/
+*.ipynb_checkpoints
+ 
+# IPython
+profile_default/
+ipython_config.py
+ 
+# pyenv
+.python-version
+ 
+# pipenv
+Pipfile.lock
+ 
+# PEP 582
+__pypackages__/
+ 
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+ 
+# SageMath parsed files
+*.sage.py
+ 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.env.local
+.env.*.local
+ 
+# Spyder project settings
+.spyderproject
+.spyproject
+ 
+# Rope project settings
+.ropeproject
+ 
+# mkdocs documentation
+/site
+ 
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+ 
+# Pyre type checker
+.pyre/
+ 
+# IDE settings
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+*.sublime-project
+*.sublime-workspace
+ 
+# OS specific files
+Thumbs.db
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+ 
+# Data files (large datasets and model weights)
+*.csv
+*.tsv
+*.xlsx
+*.xls
+*.h5
+*.hdf5
+*.pkl
+*.pickle
+*.joblib
+*.npy
+*.npz
+*.parquet
+*.feather
+ 
+# Model checkpoints and weights
+checkpoints/
+models/checkpoint*
+*.pth
+*.pt
+weights/
+ 
+# Large binary files
+*.zip
+*.tar.gz
+*.rar
+ 
+# Misc
+.DS_Store
+*.swp
+.vscode/
+*.iml

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The process of selecting relevant features for use in a model to increase accura
 <td align="center">27.</td>
 <td align="center"><a href="https://github.com/Niketkumardheeryan/ML-CaPsule/tree/main/Projects/Classification%20Algorithms">Classification Algorithms</a></td>
 <td align="center">28.</td>
-<td align="center"><a href="https://github.com/Niketkumardheeryan/ML-CaPsule/tree/main/Projects/Cloud%20Details">Cloud Details</a></td>
+<td align="center"><a href="https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Cloud%20Details">Cloud Details</a></td>
 </tr>
 <tr align="center">
 <td align="center">29.</td>


### PR DESCRIPTION
> ## Description
Adds a complete .gitignore file at the root of the repository to ignore auto-generated files, environment-specific files, and large binary files.

## Ignored Files
- Python: `__pycache__/`, `*.pyc`, `*.egg-info/`
- Jupyter: `.ipynb_checkpoints/`
- Environment: .env, venv/, etc.
- Models: *.h5, *.pkl, *.pth
- Data: *.csv, *.npy (big files)
- OS: `.DS_Store`, `Thumbs.db`
- IDE: `.idea/`, `.vscode/`

## Tests
Verify that files matching these patterns are not under git control.

Fixes #1375.