### PR TITLE
Fix Iris dataset path in Classification Algorithms notebook

### DIFF
--- a/Classification Algorithms/Classification_Algorithms.ipynb
+++ b/Classification Algorithms/Classification_Algorithms.ipynb
@@ -1,360 +1,381 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Classification Algorithms.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "k3smD5x5ZAxv"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "k3smD5x5ZAxv"
-      },
-      "source": [
-        "import numpy as np\n",
-        "import pandas as pd"
-      ],
-      "execution_count": 1,
-      "outputs": []
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
+    "id": "gzYYr6dDZLkV",
+    "outputId": "db339345-8cf2-4f1a-e6fa-e80900dcf315"
+   },
+   "outputs": [
     {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "gzYYr6dDZLkV",
-        "outputId": "db339345-8cf2-4f1a-e6fa-e80900dcf315"
-      },
-      "source": [
-        "dataset = pd.read_csv('/content/sample_data/Iris.csv')\n",
-        "print(dataset)"
-      ],
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "      Id  SepalLengthCm  ...  PetalWidthCm         Species\n",
-            "0      1            5.1  ...           0.2     Iris-setosa\n",
-            "1      2            4.9  ...           0.2     Iris-setosa\n",
-            "2      3            4.7  ...           0.2     Iris-setosa\n",
-            "3      4            4.6  ...           0.2     Iris-setosa\n",
-            "4      5            5.0  ...           0.2     Iris-setosa\n",
-            "..   ...            ...  ...           ...             ...\n",
-            "145  146            6.7  ...           2.3  Iris-virginica\n",
-            "146  147            6.3  ...           1.9  Iris-virginica\n",
-            "147  148            6.5  ...           2.0  Iris-virginica\n",
-            "148  149            6.2  ...           2.3  Iris-virginica\n",
-            "149  150            5.9  ...           1.8  Iris-virginica\n",
-            "\n",
-            "[150 rows x 6 columns]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "qykBfNcAZZ1j",
-        "outputId": "30f221c0-6765-4485-ba4d-3a8a15d07dd6"
-      },
-      "source": [
-        "dataset['Species'] = dataset['Species'].astype('category')\n",
-        "dataset['Encoded_Category'] = dataset['Species'].cat.codes\n",
-        "print(dataset)"
-      ],
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "      Id  SepalLengthCm  ...         Species  Encoded_Category\n",
-            "0      1            5.1  ...     Iris-setosa                 0\n",
-            "1      2            4.9  ...     Iris-setosa                 0\n",
-            "2      3            4.7  ...     Iris-setosa                 0\n",
-            "3      4            4.6  ...     Iris-setosa                 0\n",
-            "4      5            5.0  ...     Iris-setosa                 0\n",
-            "..   ...            ...  ...             ...               ...\n",
-            "145  146            6.7  ...  Iris-virginica                 2\n",
-            "146  147            6.3  ...  Iris-virginica                 2\n",
-            "147  148            6.5  ...  Iris-virginica                 2\n",
-            "148  149            6.2  ...  Iris-virginica                 2\n",
-            "149  150            5.9  ...  Iris-virginica                 2\n",
-            "\n",
-            "[150 rows x 7 columns]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "2euopxeqZqh-"
-      },
-      "source": [
-        "X = dataset.iloc[:,1:5].values\n",
-        "Y = dataset.iloc[:,-1].values"
-      ],
-      "execution_count": 26,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7SAJTxJna8Ts",
-        "outputId": "c08cfadf-fb70-496d-b1ef-96fd78486027"
-      },
-      "source": [
-        "print(X.shape, Y.shape)"
-      ],
-      "execution_count": 27,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(150, 4) (150,)\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Gtnqq1ZDeZAY",
-        "outputId": "f740c345-a33b-49f3-8eeb-0fec0428eba8"
-      },
-      "source": [
-        "from sklearn.model_selection import train_test_split\n",
-        "X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size = 0.2)\n",
-        "print(X_train.shape, X_test.shape)"
-      ],
-      "execution_count": 28,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(120, 4) (30, 4)\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "yod3ea5Cefuo",
-        "outputId": "9ead04a5-9f14-4e76-abfa-2094ae6f11d4"
-      },
-      "source": [
-        "#Logistic Regression\n",
-        "\n",
-        "from sklearn.linear_model import LogisticRegression\n",
-        "\n",
-        "logReg = LogisticRegression()\n",
-        "logReg.fit(X_train, Y_train)\n",
-        "\n",
-        "Y_pred = logReg.predict(X_test)\n",
-        "print(Y_test, Y_pred)"
-      ],
-      "execution_count": 29,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[2 0 0 0 0 2 2 0 1 0 2 0 0 2 1 0 1 0 2 2 1 0 1 1 1 2 1 0 0 0] [2 0 0 0 0 2 2 0 1 0 2 0 0 2 1 0 2 0 2 2 1 0 1 1 1 2 1 0 0 0]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/sklearn/linear_model/_logistic.py:940: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
-            "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
-            "\n",
-            "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
-            "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-            "Please also refer to the documentation for alternative solver options:\n",
-            "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-            "  extra_warning_msg=_LOGISTIC_SOLVER_CONVERGENCE_MSG)\n"
-          ],
-          "name": "stderr"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "-T7HHuS1em0h",
-        "outputId": "4cbb1682-211e-46a5-f18c-18569fbdc319"
-      },
-      "source": [
-        "from sklearn.metrics import  confusion_matrix, accuracy_score, precision_score, recall_score\n",
-        "\n",
-        "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred))\n",
-        "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred)) \n",
-        "print(\"Precision:\\n\", precision_score(Y_test, Y_pred, average=None))\n",
-        "print(\"Recall:\\n\", recall_score(Y_test, Y_pred, average = None))"
-      ],
-      "execution_count": 30,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Confusion Matrix:\n",
-            " [[14  0  0]\n",
-            " [ 0  7  1]\n",
-            " [ 0  0  8]]\n",
-            "Accuracy:\n",
-            " 0.9666666666666667\n",
-            "Precision:\n",
-            " [1.         1.         0.88888889]\n",
-            "Recall:\n",
-            " [1.    0.875 1.   ]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "2jHc1_UPez0b",
-        "outputId": "120ba1d3-13a4-4325-ff6a-059f8f33c061"
-      },
-      "source": [
-        "#KNN Classifier\n",
-        "\n",
-        "from sklearn.neighbors import KNeighborsClassifier\n",
-        "knn = KNeighborsClassifier()\n",
-        "knn.fit(X_train, Y_train)\n",
-        "\n",
-        "Y_pred_knn = knn.predict(X_test)\n",
-        "\n",
-        "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred_knn))\n",
-        "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred_knn)) "
-      ],
-      "execution_count": 31,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Confusion Matrix:\n",
-            " [[14  0  0]\n",
-            " [ 0  7  1]\n",
-            " [ 0  0  8]]\n",
-            "Accuracy:\n",
-            " 0.9666666666666667\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "np4G_-Cje4Ep",
-        "outputId": "b1ee65ad-09a5-4211-a632-f9c4f36b5600"
-      },
-      "source": [
-        "#Decision Tree\n",
-        "from sklearn.tree import DecisionTreeClassifier\n",
-        "\n",
-        "dtc= DecisionTreeClassifier()\n",
-        "dtc.fit(X_train, Y_train)\n",
-        "\n",
-        "Y_pred_dtc = dtc.predict(X_test)\n",
-        "\n",
-        "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred_dtc))\n",
-        "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred_dtc)) "
-      ],
-      "execution_count": 32,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Confusion Matrix:\n",
-            " [[14  0  0]\n",
-            " [ 0  7  1]\n",
-            " [ 0  1  7]]\n",
-            "Accuracy:\n",
-            " 0.9333333333333333\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "OIi3_j3me-as",
-        "outputId": "4ef852c5-2721-4c43-d2cf-6a8604e7a037"
-      },
-      "source": [
-        "#Random Forest\n",
-        "from sklearn.ensemble import RandomForestClassifier\n",
-        "\n",
-        "rfc = RandomForestClassifier()\n",
-        "rfc.fit(X_train, Y_train)\n",
-        "\n",
-        "Y_pred_rfc = rfc.predict(X_test)\n",
-        "\n",
-        "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred_rfc))\n",
-        "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred_rfc))"
-      ],
-      "execution_count": 33,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Confusion Matrix:\n",
-            " [[14  0  0]\n",
-            " [ 0  7  1]\n",
-            " [ 0  1  7]]\n",
-            "Accuracy:\n",
-            " 0.9333333333333333\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Id  SepalLengthCm  SepalWidthCm  PetalLengthCm  PetalWidthCm  \\\n",
+      "0      1            5.1           3.5            1.4           0.2   \n",
+      "1      2            4.9           3.0            1.4           0.2   \n",
+      "2      3            4.7           3.2            1.3           0.2   \n",
+      "3      4            4.6           3.1            1.5           0.2   \n",
+      "4      5            5.0           3.6            1.4           0.2   \n",
+      "..   ...            ...           ...            ...           ...   \n",
+      "145  146            6.7           3.0            5.2           2.3   \n",
+      "146  147            6.3           2.5            5.0           1.9   \n",
+      "147  148            6.5           3.0            5.2           2.0   \n",
+      "148  149            6.2           3.4            5.4           2.3   \n",
+      "149  150            5.9           3.0            5.1           1.8   \n",
+      "\n",
+      "            Species  \n",
+      "0       Iris-setosa  \n",
+      "1       Iris-setosa  \n",
+      "2       Iris-setosa  \n",
+      "3       Iris-setosa  \n",
+      "4       Iris-setosa  \n",
+      "..              ...  \n",
+      "145  Iris-virginica  \n",
+      "146  Iris-virginica  \n",
+      "147  Iris-virginica  \n",
+      "148  Iris-virginica  \n",
+      "149  Iris-virginica  \n",
+      "\n",
+      "[150 rows x 6 columns]\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "dataset = pd.read_csv(r\"C:\\Users\\kmuke\\Downloads\\ML-CaPsule-master\\ML-CaPsule\\Classification Algorithms\\Iris.csv\")\n",
+    "print(dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qykBfNcAZZ1j",
+    "outputId": "30f221c0-6765-4485-ba4d-3a8a15d07dd6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Id  SepalLengthCm  SepalWidthCm  PetalLengthCm  PetalWidthCm  \\\n",
+      "0      1            5.1           3.5            1.4           0.2   \n",
+      "1      2            4.9           3.0            1.4           0.2   \n",
+      "2      3            4.7           3.2            1.3           0.2   \n",
+      "3      4            4.6           3.1            1.5           0.2   \n",
+      "4      5            5.0           3.6            1.4           0.2   \n",
+      "..   ...            ...           ...            ...           ...   \n",
+      "145  146            6.7           3.0            5.2           2.3   \n",
+      "146  147            6.3           2.5            5.0           1.9   \n",
+      "147  148            6.5           3.0            5.2           2.0   \n",
+      "148  149            6.2           3.4            5.4           2.3   \n",
+      "149  150            5.9           3.0            5.1           1.8   \n",
+      "\n",
+      "            Species  Encoded_Category  \n",
+      "0       Iris-setosa                 0  \n",
+      "1       Iris-setosa                 0  \n",
+      "2       Iris-setosa                 0  \n",
+      "3       Iris-setosa                 0  \n",
+      "4       Iris-setosa                 0  \n",
+      "..              ...               ...  \n",
+      "145  Iris-virginica                 2  \n",
+      "146  Iris-virginica                 2  \n",
+      "147  Iris-virginica                 2  \n",
+      "148  Iris-virginica                 2  \n",
+      "149  Iris-virginica                 2  \n",
+      "\n",
+      "[150 rows x 7 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset['Species'] = dataset['Species'].astype('category')\n",
+    "dataset['Encoded_Category'] = dataset['Species'].cat.codes\n",
+    "print(dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "2euopxeqZqh-"
+   },
+   "outputs": [],
+   "source": [
+    "X = dataset.iloc[:,1:5].values\n",
+    "Y = dataset.iloc[:,-1].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "7SAJTxJna8Ts",
+    "outputId": "c08cfadf-fb70-496d-b1ef-96fd78486027"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(150, 4) (150,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(X.shape, Y.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Gtnqq1ZDeZAY",
+    "outputId": "f740c345-a33b-49f3-8eeb-0fec0428eba8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(120, 4) (30, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size = 0.2)\n",
+    "print(X_train.shape, X_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "yod3ea5Cefuo",
+    "outputId": "9ead04a5-9f14-4e76-abfa-2094ae6f11d4"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2 0 0 0 0 1 1 0 1 2 2 0 1 1 0 0 1 2 2 0 0 0 0 2 0 0 2 0 2 1] [2 0 0 0 0 1 2 0 1 2 2 0 1 2 0 0 1 2 2 0 0 0 0 2 0 0 2 0 2 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Logistic Regression\n",
+    "\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "logReg = LogisticRegression()\n",
+    "logReg.fit(X_train, Y_train)\n",
+    "\n",
+    "Y_pred = logReg.predict(X_test)\n",
+    "print(Y_test, Y_pred)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "-T7HHuS1em0h",
+    "outputId": "4cbb1682-211e-46a5-f18c-18569fbdc319"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Confusion Matrix:\n",
+      " [[15  0  0]\n",
+      " [ 0  5  2]\n",
+      " [ 0  0  8]]\n",
+      "Accuracy:\n",
+      " 0.9333333333333333\n",
+      "Precision:\n",
+      " [1.  1.  0.8]\n",
+      "Recall:\n",
+      " [1.         0.71428571 1.        ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import  confusion_matrix, accuracy_score, precision_score, recall_score\n",
+    "\n",
+    "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred))\n",
+    "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred)) \n",
+    "print(\"Precision:\\n\", precision_score(Y_test, Y_pred, average=None))\n",
+    "print(\"Recall:\\n\", recall_score(Y_test, Y_pred, average = None))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "2jHc1_UPez0b",
+    "outputId": "120ba1d3-13a4-4325-ff6a-059f8f33c061"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Confusion Matrix:\n",
+      " [[15  0  0]\n",
+      " [ 0  6  1]\n",
+      " [ 0  0  8]]\n",
+      "Accuracy:\n",
+      " 0.9666666666666667\n"
+     ]
+    }
+   ],
+   "source": [
+    "#KNN Classifier\n",
+    "\n",
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "knn = KNeighborsClassifier()\n",
+    "knn.fit(X_train, Y_train)\n",
+    "\n",
+    "Y_pred_knn = knn.predict(X_test)\n",
+    "\n",
+    "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred_knn))\n",
+    "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred_knn)) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "np4G_-Cje4Ep",
+    "outputId": "b1ee65ad-09a5-4211-a632-f9c4f36b5600"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Confusion Matrix:\n",
+      " [[15  0  0]\n",
+      " [ 0  5  2]\n",
+      " [ 0  0  8]]\n",
+      "Accuracy:\n",
+      " 0.9333333333333333\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Decision Tree\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
+    "\n",
+    "dtc= DecisionTreeClassifier()\n",
+    "dtc.fit(X_train, Y_train)\n",
+    "\n",
+    "Y_pred_dtc = dtc.predict(X_test)\n",
+    "\n",
+    "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred_dtc))\n",
+    "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred_dtc)) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "OIi3_j3me-as",
+    "outputId": "4ef852c5-2721-4c43-d2cf-6a8604e7a037"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Confusion Matrix:\n",
+      " [[15  0  0]\n",
+      " [ 0  5  2]\n",
+      " [ 0  0  8]]\n",
+      "Accuracy:\n",
+      " 0.9333333333333333\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Random Forest\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "\n",
+    "rfc = RandomForestClassifier()\n",
+    "rfc.fit(X_train, Y_train)\n",
+    "\n",
+    "Y_pred_rfc = rfc.predict(X_test)\n",
+    "\n",
+    "print(\"Confusion Matrix:\\n\", confusion_matrix(Y_test, Y_pred_rfc))\n",
+    "print(\"Accuracy:\\n\", accuracy_score(Y_test, Y_pred_rfc))"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Classification Algorithms.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/Classification Algorithms/Classification_Algorithms.ipynb
+++ b/Classification Algorithms/Classification_Algorithms.ipynb
@@ -121,8 +121,7 @@
    },
    "outputs": [],
    "source": [
-    "X = dataset.iloc[:,1:5].values\n",
-    "Y = dataset.iloc[:,-1].values"
+    "feature_cols = ['SepalLengthCm', 'SepalWidthCm', 'PetalLengthCm', 'PetalWidthCm']\nX = dataset[feature_cols].values\nY = dataset['Encoded_Category'].values"
    ]
   },
   {


### PR DESCRIPTION
## Description

Fixed the dataset file path in `Classification_Algorithms.ipynb`.

Previously, the notebook attempted to load the Iris dataset using a Google Colab-specific path:

`/content/sample_data/Iris.csv`

This caused execution issues in local environments.

The path has been updated to use the local dataset file:

`Iris.csv`

This improves portability and allows the notebook to run correctly outside Google Colab.
