### PR TITLE
Fix heart disease notebook model evaluation, pipeline workflow, and README link

### DIFF
--- a/Heart_Predection/HeartDisease.ipynb
+++ b/Heart_Predection/HeartDisease.ipynb
@@ -1270,7 +1270,8 @@
         "id": "_tR6oQ9oLJSt"
       },
       "source": [
-        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.model_selection import GridSearchCV\n",
+        "from sklearn.pipeline import Pipeline\n",
         "from sklearn.preprocessing import StandardScaler\n",
         "standardScaler = StandardScaler()\n",
         "columns_to_scale = ['age', 'trestbps', 'chol', 'thalach', 'oldpeak']\n",
@@ -1749,8 +1750,12 @@
         "id": "zMlqMgrzNQRA"
       },
       "source": [
-        "lr = LogisticRegression()\n",
-        "score=cross_val_score(lr,x,y)"
+        "pipeline = Pipeline([('scaler', StandardScaler()), ('classifier', LogisticRegression(solver='liblinear', max_iter=1000))])\n",
+        "param_grid = {'classifier__C': [0.01, 0.1, 1, 10], 'classifier__penalty': ['l1', 'l2']}\n",
+        "grid_search = GridSearchCV(pipeline, param_grid, cv=10, scoring='accuracy')\n",
+        "grid_search.fit(x, y)\n",
+        "print('Best parameters:', grid_search.best_params_)\n",
+        "print('Best cross-validation score:', grid_search.best_score_)\n"
       ],
       "execution_count": null,
       "outputs": []

--- a/Heart_Predection/Readme.md
+++ b/Heart_Predection/Readme.md
@@ -7,7 +7,7 @@ In the model Data Analysis has also been performed
 
 ### Dataset
 
-Dataset used can be dowloaded from [here](https://www.kaggle.com/ronitf/heart-disease-uci) 
+Dataset used can be dowloaded from [here](https://www.kaggle.com/datasets/ronitf/heart-disease-uci) 
 <br>
 
 


### PR DESCRIPTION
Fixes  #1310
- Updated HeartDisease.ipynb to replace the broken `LogisticRegression` cross-validation block with a proper `Pipeline` + `GridSearchCV` evaluation
- Removed unused `train_test_split` import and added necessary `GridSearchCV`/`Pipeline` imports
- Preserved notebook outputs and execution state while applying source-only changes
- Corrected Readme.md dataset URL to the Kaggle Heart Disease UCI dataset