### PR TITLE
fix: add random_state to train_test_split for reproducibility

### DIFF
--- a/Bitcoin Price Prediction Web App/app.py
+++ b/Bitcoin Price Prediction Web App/app.py
@@ -47,7 +47,7 @@ Y=bitcoin["Marketcap"]
 
 from sklearn.linear_model import Lasso
 Ls=Lasso()
-xtrain,xtest,ytrain,ytest=train_test_split(X,Y,test_size=0.2)
+xtrain,xtest,ytrain,ytest=train_test_split(X,Y,test_size=0.2, random_state=42)
 Ls.fit(xtrain,ytrain)
 
 if r=='Bitcoin Price':

--- a/Chicken_Disease_Classification/research/mlflow_exp/example.py
+++ b/Chicken_Disease_Classification/research/mlflow_exp/example.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         )
 
     # Split the data into training and test sets. (0.75, 0.25) split.
-    train, test = train_test_split(data)
+    train, test = train_test_split(data , random_state=42)
 
     # The predicted column is "quality" which is a scalar from [3, 9]
     train_x = train.drop(["quality"], axis=1)

--- a/Social Media Fake Accounts Detection with Interactive UI/jserver/model.py
+++ b/Social Media Fake Accounts Detection with Interactive UI/jserver/model.py
@@ -73,8 +73,7 @@ for index in range(len(user_object["fake"])):
     X[len(user_object["legit"]) + index] = user_object["fake"][index] / bound  # Normalizing Data [0 <--> 1]
     Y[len(user_object["legit"]) + index] = 1
 
-X_train_data, X_test_data, y_train_data, y_test_data = train_test_split(X, Y,
-                                                                        test_size=0.24, random_state=42)
+X_train_data, X_test_data, y_train_data, y_test_data = train_test_split(X, Y, test_size=0.24, random_state=42)
 
 early_stopping = EarlyStopping(monitor='val_loss', patience=2)
 


### PR DESCRIPTION
Closes #1575

## Changes Made
- Added `random_state=42` to applicable `train_test_split()` calls to ensure reproducible and consistent results across runs.

## Notes
- Only 3 files required modification.
- The remaining mentioned files either already had `random_state` configured or did not contain relevant `train_test_split()` usage.