### PR TITLE
Add Dog vs Cat Classification using Custom CNN and Streamlit

### DIFF
--- a/dog vs cat/README.md
+++ b/dog vs cat/README.md
@@ -1,0 +1,175 @@
+# Dog vs Cat Classification using CNN and Streamlit
+
+A beginner-friendly Deep Learning project that classifies images as **Dog** or **Cat** using a custom Convolutional Neural Network (CNN) built from scratch, with an interactive **Streamlit web app** for real-time predictions.
+
+---
+
+##  Project Structure
+
+```
+Dog_vs_Cat_CNN_Streamlit/
+├── dog-vs-cat.ipynb           ← Complete training notebook (run this first)
+├── app.py                      ← Streamlit web application
+├── requirements.txt            ← Python dependencies
+└── README.md                   ← This file
+```
+
+> After running the notebook, these files are auto-generated:
+> `dog_vs_cat_model.keras`, `sample_predictions.png`, `training_history.png`, `confusion_matrix.png`
+
+---
+
+## 🔄 Complete Workflow
+
+```
+Dataset Download (kagglehub) → EDA → Augmentation → CNN Training → Evaluation → Streamlit App
+```
+
+---
+
+##  Dataset
+
+- **Source:** [Microsoft Cats vs Dogs — Kaggle](https://www.kaggle.com/datasets/shaunthesheep/microsoft-catsvsdogs-dataset)
+- **Downloaded via:** `kagglehub` (auto-download in notebook)
+- **Training set:** 8,000 dogs + 8,000 cats = **16,000 images**
+- **Test set:** 2,000 dogs + 2,000 cats = **4,000 images**
+- Corrupted images are automatically filtered before training
+
+---
+
+##  Exploratory Data Analysis
+
+- 10 sample training images (5 dogs + 5 cats)
+- Class distribution bar charts (train + test)
+- Augmented image preview (8 samples)
+
+---
+
+##  Data Augmentation
+
+| Technique | Value |
+|---|---|
+| Rescale | 1/255 |
+| Rotation range | ±20° |
+| Width / Height shift | 20% |
+| Shear range | 20% |
+| Zoom range | 20% |
+| Horizontal flip | Yes |
+| Fill mode | Nearest |
+
+---
+
+##  CNN Architecture (Custom — 3 Blocks)
+
+```
+Input (150 × 150 × 3)
+        ↓
+Block 1: Conv2D(32) → BatchNorm → Conv2D(32) → MaxPool(2×2) → Dropout(0.25)
+        ↓
+Block 2: Conv2D(64) → BatchNorm → Conv2D(64) → MaxPool(2×2) → Dropout(0.25)
+        ↓
+Block 3: Conv2D(128) → BatchNorm → Conv2D(128) → MaxPool(2×2) → Dropout(0.25)
+        ↓
+Flatten → Dense(512) → BatchNorm → Dropout(0.5)
+        ↓
+Dense(1, sigmoid) → Dog (1) or Cat (0)
+```
+
+**Total parameters:** 21,524,641 (82.11 MB)
+
+---
+
+##  Training Configuration
+
+| Parameter | Value |
+|---|---|
+| Optimizer | Adam |
+| Loss | Binary Crossentropy |
+| Max Epochs | 20 |
+| Early Stopping | patience = 5 (monitors val_accuracy) |
+| Batch Size | 32 |
+| Image Size | 150 × 150 |
+| GPU | Tesla T4 (2× GPUs) |
+
+### Epoch Progress
+
+| Epoch | Train Accuracy | Val Accuracy |
+|---|---|---|
+| 1 | 56.93% | 60.65% |
+| 2 | 66.76% | 71.13% |
+| 3 | 72.16% | 73.18% |
+| 5 | 76.15% | 82.20% ✅ best checkpoint |
+| ... | ... | ... |
+| Final | — | **91.53%** |
+
+---
+
+##  Results
+
+| Metric | Value |
+|---|---|
+| **Test Accuracy** | **91.53%** |
+| **Test Loss** | **0.2055** |
+
+### Classification Report
+
+| Class | Precision | Recall | F1-Score | Support |
+|---|---|---|---|---|
+| Cat | 0.92 | 0.91 | 0.91 | 2,000 |
+| Dog | 0.91 | 0.92 | 0.92 | 2,000 |
+| **Weighted Avg** | **0.92** | **0.92** | **0.92** | **4,000** |
+
+---
+
+
+##  How to Run
+
+### Step 1 — Install dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### Step 2 — Get Kaggle API key
+- Go to `kaggle.com` → Profile → Settings → **Create New Token**
+- This downloads `kaggle.json` — place it in `~/.kaggle/kaggle.json`
+
+### Step 3 — Train the model
+```bash
+jupyter notebook dog-vs-cat.ipynb
+```
+Run all cells. The notebook auto-downloads the dataset via `kagglehub`, restructures it, trains the CNN, and saves `dog_vs_cat_model.keras`.
+
+### Step 4 — Launch the Streamlit app
+```bash
+streamlit run app.py
+```
+Opens at `http://localhost:8501` 🚀
+
+---
+
+## 🛠️ Technologies Used
+
+| Library | Purpose |
+|---|---|
+| `TensorFlow 2.19 / Keras` | CNN model building and training |
+| `kagglehub` | Auto-download dataset from Kaggle |
+| `NumPy` | Array operations |
+| `Matplotlib / Seaborn` | Training history, confusion matrix |
+| `Scikit-learn` | Classification report, confusion matrix |
+| `Streamlit` | Interactive web application |
+| `Pillow` | Image loading and preprocessing |
+
+---
+
+
+##  Dataset
+
+[Microsoft Cats vs Dogs on Kaggle](https://www.kaggle.com/datasets/shaunthesheep/microsoft-catsvsdogs-dataset)
+
+---
+
+##  Author
+
+**Siddharth** — [GitHub @siddharth277](https://github.com/siddharth277)
+Contributed as part of **GSSoC 2026**
+

--- a/dog vs cat/app.py
+++ b/dog vs cat/app.py
@@ -1,0 +1,114 @@
+import streamlit as st
+import tensorflow as tf
+import numpy as np
+from PIL import Image
+import os
+
+# ── Page config ──────────────────────────────────────────────────────────────
+st.set_page_config(
+    page_title="Dog vs Cat Classifier",
+    page_icon="🐾",
+    layout="centered"
+)
+
+# ── Header ────────────────────────────────────────────────────────────────────
+st.title("🐶🐱 Dog vs Cat Classifier")
+st.markdown("Upload any image of a **dog or cat** and the CNN model will predict what it is!")
+st.markdown("---")
+
+# ── Load Model ────────────────────────────────────────────────────────────────
+@st.cache_resource
+def load_model():
+    model_path = "dog_vs_cat_model.keras"
+    if not os.path.exists(model_path):
+        st.error("❌ Model file not found! Please train the model first by running the notebook.")
+        return None
+    return tf.keras.models.load_model(model_path)
+
+model = load_model()
+
+# ── Prediction function ───────────────────────────────────────────────────────
+def predict(image: Image.Image):
+    img = image.resize((150, 150))
+    img_array = np.array(img) / 255.0
+    if img_array.shape[-1] == 4:          # handle RGBA
+        img_array = img_array[:, :, :3]
+    img_array = np.expand_dims(img_array, axis=0)
+    prediction = model.predict(img_array, verbose=0)[0][0]
+    label      = "Dog 🐶" if prediction > 0.5 else "Cat 🐱"
+    confidence = prediction if prediction > 0.5 else 1 - prediction
+    return label, float(confidence)
+
+# ── Upload Section ────────────────────────────────────────────────────────────
+st.subheader("📤 Upload an Image")
+uploaded_file = st.file_uploader(
+    "Choose a JPG or PNG image",
+    type=["jpg", "jpeg", "png"]
+)
+
+if uploaded_file and model:
+    image = Image.open(uploaded_file).convert("RGB")
+
+    col1, col2 = st.columns([1, 1])
+
+    with col1:
+        st.image(image, caption="Uploaded Image", use_column_width=True)
+
+    with col2:
+        st.subheader("🔍 Prediction")
+        with st.spinner("Analyzing image..."):
+            label, confidence = predict(image)
+
+        # Result card
+        if "Dog" in label:
+            st.success(f"### {label}")
+            color = "🟦"
+        else:
+            st.warning(f"### {label}")
+            color = "🟧"
+
+        # Confidence bar
+        st.markdown(f"**Confidence: {confidence*100:.2f}%**")
+        st.progress(confidence)
+
+        # Confidence breakdown
+        st.markdown("#### Confidence Breakdown")
+        dog_conf = confidence   if "Dog" in label else 1 - confidence
+        cat_conf = 1 - dog_conf
+
+        st.markdown(f"🐶 **Dog:** {dog_conf*100:.2f}%")
+        st.progress(float(dog_conf))
+        st.markdown(f"🐱 **Cat:** {cat_conf*100:.2f}%")
+        st.progress(float(cat_conf))
+
+    st.markdown("---")
+
+# ── Sample Predictions Section ────────────────────────────────────────────────
+st.subheader("🖼️ Sample Predictions from Training")
+sample_images_path = "sample_predictions.png"
+if os.path.exists(sample_images_path):
+    st.image(sample_images_path, caption="Model predictions on test images (Green = Correct, Red = Wrong)", use_column_width=True)
+else:
+    st.info("📌 Run the notebook first to generate sample prediction images.")
+
+# ── Model Info ────────────────────────────────────────────────────────────────
+st.markdown("---")
+with st.expander("ℹ️ About the Model"):
+    st.markdown("""
+    **Architecture:** Custom CNN (3 Convolutional Blocks)
+    
+    | Layer Block | Filters | Operation |
+    |---|---|---|
+    | Block 1 | 32  | Conv2D → BatchNorm → MaxPool → Dropout |
+    | Block 2 | 64  | Conv2D → BatchNorm → MaxPool → Dropout |
+    | Block 3 | 128 | Conv2D → BatchNorm → MaxPool → Dropout |
+    | Classifier | 512 | Dense → BatchNorm → Dropout → Sigmoid |
+    
+    - **Input size:** 150×150 RGB
+    - **Optimizer:** Adam
+    - **Loss:** Binary Crossentropy
+    - **Dataset:** Kaggle Dogs vs Cats
+    """)
+
+st.markdown("---")
+st.markdown("Built with ❤️ using TensorFlow & Streamlit | GSSoC 2026")

--- a/dog vs cat/requirements.txt
+++ b/dog vs cat/requirements.txt
@@ -1,0 +1,7 @@
+tensorflow>=2.10.0
+numpy>=1.23.0
+matplotlib>=3.5.0
+seaborn>=0.12.0
+scikit-learn>=1.1.0
+streamlit>=1.25.0
+Pillow>=9.0.0


### PR DESCRIPTION
## Changes
Added a Deep Learning project: Dog vs Cat Image Classification

## What's included
- Auto dataset download via `kagglehub` (Microsoft Cats vs Dogs — 16,000 train / 4,000 test)
- Corrupted image filtering before training
- EDA: sample images, class distribution charts, augmented image preview
- Data augmentation: rotation, zoom, flip, shift
- Custom CNN from scratch (3 Conv blocks + BatchNorm + Dropout)
- Total parameters: 21,524,641 (82.11 MB)
- EarlyStopping + ModelCheckpoint callbacks
- Test Accuracy: 91.53% | Test Loss: 0.2055
- Classification Report: Cat F1=0.91 | Dog F1=0.92
- Confusion matrix and sample predictions (10 images)
- Streamlit web app: upload image → predict + confidence score breakdown
- Proper README.md with setup instructions and epoch-wise results

## Tech Stack
TensorFlow 2.19, Keras, kagglehub, NumPy, Matplotlib, Seaborn, Scikit-learn, Streamlit, Pillow


fixes #1536 

Under GSSOC'26