### PR TITLE
Fix malformed `.github/auto-label.json` configuration

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -2,8 +2,8 @@
   "rules": {
     "Frontend": ["*.js", "*.css", "*.html"],
     "Backend": ["app/", "*.rb"],
-    "CI": ".circleci"
+    "CI": [".circleci"],
     "C/CPP": ["*.cpp", "*.c"],
-    "Python": ["*.py", "*.ipynb"],
+    "Python": ["*.py", "*.ipynb"]
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes malformed JSON syntax in `.github/auto-label.json`.
Fixes #1624

### Changes Made

* Fixed missing comma between label rules
* Normalized the `CI` rule structure
* Removed trailing invalid comma
* Verified the JSON parses successfully

### Impact

This restores a valid configuration for repository label automation while preserving the existing label taxonomy and behavior.
