### PR TITLE
fix: resolve unclosed markdown code blocks in README installation guides 

### DIFF
--- a/Dark Pattern Detection/Readme.md
+++ b/Dark Pattern Detection/Readme.md
@@ -73,6 +73,7 @@ Clone the repository
 2. run this command in terminal
    ```bash
    python scrapp_ocr_csv.py
+   ```
 
 ## Example output   
    ```python 

--- a/GUI-JARVIS/README.md
+++ b/GUI-JARVIS/README.md
@@ -72,6 +72,7 @@ pip install re
 pip install smtplib
 pip install winsound
 pip install wikipedia
+```
 pip install sys
 pip install os
 pip install webbrowser


### PR DESCRIPTION
This PR resolves the unexpected layout rendering issues reported in #1383. 

Changes made:
- Added missing closing triple backticks (```) to the code blocks under the "Installation" and "Usage" sections across  `Dark Pattern Detection`, and `GUI-JARVIS` README files.