### PR TITLE
fix: add common gitignore template for ML/DL projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Virtual environments
+venv/
+env/
+.venv/
+
+# ML model files
+*.pt
+*.pth
+*.ckpt
+*.h5
+
+# Dataset folders
+datasets/
+data/
+tmp_data/
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Changes Made

* Added a common `.gitignore` template for ML/DL projects
* Ignored Python cache files (`__pycache__`)
* Ignored Jupyter notebook checkpoints
* Ignored virtual environment folders
* Ignored common ML model weight files
* Ignored temporary dataset folders and OS-specific files

Fixes #1655
