### PR TITLE
Fix: missing import 'os' in Brain Tumor Web App

### DIFF
--- a/Brain Tumor Detection/Web App/app.py
+++ b/Brain Tumor Detection/Web App/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, request
 import numpy as np
 import tensorflow as tf
+import os
 from PIL import Image
 import io
 import base64


### PR DESCRIPTION
### Description
This PR fixes a critical crash in the Brain Tumor Detection Flask web app due to a missing `import os` statement when resolving the `best_model.h5` path.

### Fixes
Closes #1672