### PR TITLE
Bug: Fix correct copy-paste salary typo and format output in Bitcoin App

### DIFF
--- a/Bitcoin Price Prediction Web App/app.py
+++ b/Bitcoin Price Prediction Web App/app.py
@@ -60,7 +60,7 @@ if r=='Bitcoin Price':
     
     ypred=Ls.predict([[High,Low,Open,Close,volume]])
     if(st.button("Predict")):
-        st.success(f"Your Predicted Salary Is {abs(ypred)}")
+        st.success(f"Your Predicted Bitcoin Marketcap Is ${abs(ypred[0]):,.2f}")
         
 
     


### PR DESCRIPTION
### Description
This PR fixes a funny copy-paste string bug in the Bitcoin Price Prediction Streamlit app. The previous success message mistakenly printed "Your Predicted Salary Is ..." instead of "Your Predicted Bitcoin Marketcap Is ...". Additionally, this PR handles the output value correctly as a formatted currency string instead of printing the raw NumPy array.

### Fixes
Closes #1674