### PR TITLE
fix: video stream end crash in Testemotion.py by reordering frame resize check

### DIFF
--- a/Testemotion.py
+++ b/Testemotion.py
@@ -79,9 +79,9 @@ cap = cv2.VideoCapture(0)
 while True:
     # Find Haar cascade to draw bounding box around face
     ret, frame = cap.read()
-    frame = cv2.resize(frame, (1280, 720))
     if not ret:
         break
+    frame = cv2.resize(frame, (1280, 720))
     face_detector = cv2.CascadeClassifier('haarcascade_frontalface_default.xml')
     gray_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
 


### PR DESCRIPTION
This PR reorders the loop checks in `Testemotion.py` to verify `ret` before resizing the frame, avoiding crashes when capture terminates.