### PR TITLE
fix: requirements.txt syntax error in SQL injection detection project

### DIFF
--- a/SQL injection detection/requirements.txt
+++ b/SQL injection detection/requirements.txt
@@ -5,4 +5,4 @@ matplotlib==3.6.3
 scikit-learn==1.2.1
 tensorflow==2.11.0
 keras==2.11.0
---versions-- above the defined may or may not work.
+# versions above the defined may or may not work.


### PR DESCRIPTION
This PR prefixes the warning line with `#` comment token to conform to pip requirements format.