### PR TITLE
perf & fix: chatbot startup speedup via caching and relative corpus path loading

### DIFF
--- a/Unique Chatbot/chatbot.py
+++ b/Unique Chatbot/chatbot.py
@@ -14,11 +14,12 @@ warnings.filterwarnings('ignore')
 
 import nltk
 from nltk.stem import WordNetLemmatizer
-nltk.download('popular', quiet=True) # for downloading packages
 
-# uncomment the following only the first time
-#nltk.download('punkt') # first-time use only
-#nltk.download('wordnet') # first-time use only
+try:
+    nltk.data.find('tokenizers/punkt')
+    nltk.data.find('corpora/wordnet')
+except LookupError:
+    nltk.download('popular', quiet=True)
 
 
 #Reading in the corpus

--- a/Unique Chatbot/chatbot.py
+++ b/Unique Chatbot/chatbot.py
@@ -22,8 +22,11 @@ except LookupError:
     nltk.download('popular', quiet=True)
 
 
+import os
+
 #Reading in the corpus
-with open('chatbot.txt','r', encoding='utf8', errors ='ignore') as fin:
+corpus_path = os.path.join(os.path.dirname(__file__), 'chatbot.txt')
+with open(corpus_path,'r', encoding='utf8', errors ='ignore') as fin:
     raw = fin.read().lower()
 
 #TOkenisation


### PR DESCRIPTION
This PR caches NLTK downloads so they are skipped if files are cached locally, and uses `os.path` to load `chatbot.txt` dynamically relative to script location.