### PR TITLE
fix: malformed header SVG logo tags in index, home, contribution, & login html pages

### DIFF
--- a/website ML-CaPsule/contribution.html
+++ b/website ML-CaPsule/contribution.html
@@ -10,6 +10,7 @@
         <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
           <a class="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
             <img src="logo.png" alt="Logo" class="w-10 h-10 rounded-full">
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10 text-white p-2 bg-indigo-500 rounded-full ml-3" viewBox="0 0 24 24">
               <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
             </svg>
             <span class="ml-3 text-xl">ML-CaPsule</span>

--- a/website ML-CaPsule/home.html
+++ b/website ML-CaPsule/home.html
@@ -14,6 +14,7 @@
         <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
           <a class="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
             <img src="logo.png" alt="Logo" class="w-10 h-10 rounded-full">
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10 text-white p-2 bg-indigo-500 rounded-full ml-3" viewBox="0 0 24 24">
               <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
             </svg>
             <span class="ml-3 text-xl">ML-CaPsule</span>

--- a/website ML-CaPsule/index.html
+++ b/website ML-CaPsule/index.html
@@ -14,6 +14,7 @@
         <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
           <a class="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
             <img src="logo.png" alt="Logo" class="w-10 h-10 rounded-full">
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10 text-white p-2 bg-indigo-500 rounded-full ml-3" viewBox="0 0 24 24">
               <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
             </svg>
             <span class="ml-3 text-xl">ML-CaPsule</span>

--- a/website ML-CaPsule/login.html
+++ b/website ML-CaPsule/login.html
@@ -14,6 +14,7 @@
         <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
           <a class="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
             <img src="logo.png" alt="Logo" class="w-10 h-10 rounded-full">
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10 text-white p-2 bg-indigo-500 rounded-full ml-3" viewBox="0 0 24 24">
               <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
             </svg>
             <span class="ml-3 text-xl">ML-CaPsule</span>


### PR DESCRIPTION
This PR adds the missing opening `<svg>` tag matching the path and closing svg elements in brand headers.