### PR TITLE
refactor: improve build_readme.py by scanning local directories instead of web scraping

### DIFF
--- a/build_readme.py
+++ b/build_readme.py
@@ -1,11 +1,7 @@
-import requests
-from bs4 import BeautifulSoup
 import pathlib
 import re
 
-
 ROOT_PATH = pathlib.Path(__file__).parent.resolve()
-FEED_URL = 'https://github.com/Niketkumardheeryan/Hands-on-ML-Basic-to-Advance-'
 
 def replace_chunk(content, marker, chunk, inline=False):
     r = re.compile(
@@ -18,36 +14,32 @@ def replace_chunk(content, marker, chunk, inline=False):
     return r.sub(chunk, content)
 
 
-
-def Exract_files_names():
-	req = requests.get(FEED_URL)
-	soup = BeautifulSoup(req.text, 'html.parser')
-	temp=[]
-	li = soup.findAll('div', class_="Box-row Box-row--focus-gray py-2 d-flex position-relative js-navigation-item")
-	for i in li:
-		for x in i.findAll('a',class_="js-navigation-open Link--primary"):
-			if(x.text!=".github" and x.text!="CODE_OF_CONDUCT.md" and x.text!="CONTRIBUTING_GUIDELINES.md" and x.text!=".github/workflows" and x.text!="build_readme.py" and x.text!="requirements.txt" and x.text!="README.md" and x.text!="download statistics.jpg" and x.text!="img" and x.text!="ml img.jpg"):
-				temp2={
-                	'fname' : x.text,
-                	'furl': x["href"].split('/')[-1]
-				   		}
-				temp.append(temp2)
-			else:pass
-	return temp
+def extract_file_names():
+    exclude_list = {
+        ".git", ".github", ".idea", "__pycache__", "CODE_OF_CONDUCT.md", 
+        "CONTRIBUTING_GUIDELINES.md", "build_readme.py", "requirements.txt", 
+        "README.md", "download statistics.jpg", "img", "ml img.jpg"
+    }
+    
+    temp = []
+    for path in sorted(ROOT_PATH.iterdir()):
+        if path.name not in exclude_list and not path.name.startswith('.'):
+            # Encode URL properly if needed, but for simplicity we keep the original format
+            temp.append({
+                'fname': path.name,
+                'furl': path.name.replace(" ", "%20")
+            })
+    return temp
 
 
 if __name__ == "__main__":
     readme = ROOT_PATH / "README.md"
-    readme_contents = readme.open().read()
+    readme_contents = readme.open("r", encoding="utf-8").read()
 
-    file_names = Exract_files_names()
-    file_md="\n\n".join(["- {}".format(i) for i in file_names])
+    file_names = extract_file_names()
     file_md = "\n".join(
         ["| [{fname}]({furl}) |".format(**i) for i in file_names]
     )
 
-    
     readme_contents = replace_chunk(readme_contents, "Projects", "| Content List | \n | --------------- | \n" + file_md)
-    readme.open("w").write(readme_contents)
-
-
+    readme.open("w", encoding="utf-8").write(readme_contents)


### PR DESCRIPTION
Closed #1744 

## Changes
- Refactored `build_readme.py` to use `pathlib`.
- Removed `requests` and `bs4` dependencies.
- The script now natively scans the local directory structure to build the Content List for the README, making it 100% reliable.