### PR TITLE
fix: ignore Python cache files and DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*$py.class
+.DS_Store


### PR DESCRIPTION
Closed #1756 

## Changes
- Created a root-level `.gitignore` file.
- Added rules to automatically exclude `__pycache__/`, `*.py[cod]`, `*$py.class`, and `.DS_Store`.