### PR TITLE
Bug: Fix make working directory of chatbot corpus

### DIFF
--- a/Unique Chatbot/chatbot.py
+++ b/Unique Chatbot/chatbot.py
@@ -3,6 +3,7 @@
 
 #import necessary libraries
 import io
+import os
 import random
 import string # to process standard python strings
 import warnings
@@ -20,9 +21,11 @@ nltk.download('popular', quiet=True) # for downloading packages
 #nltk.download('punkt') # first-time use only
 #nltk.download('wordnet') # first-time use only
 
+# Reading in the corpus with robust path handling
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+corpus_path = os.path.join(BASE_DIR, 'chatbot.txt')
 
-#Reading in the corpus
-with open('chatbot.txt','r', encoding='utf8', errors ='ignore') as fin:
+with open(corpus_path, 'r', encoding='utf8', errors='ignore') as fin:
     raw = fin.read().lower()
 
 #TOkenisation


### PR DESCRIPTION
Description

Fixed the `FileNotFoundError` issue in "Unique Chatbot/chatbot.py" by implementing robust file path handling for the corpus file.

Changes Made-

* Added os.path based dynamic path handling
* Replaced hardcoded relative file path with an absolute path generated from the script directory
* Ensured the chatbot works correctly regardless of the current working directory

Testing

* Successfully executed the chatbot script from the project root directory
* Verified that the corpus file loads correctly without path-related errors

Fixes #1754
