### PR TITLE
refactor: scan local directories in build_readme.py

### DIFF
--- a/build_readme.py
+++ b/build_readme.py
@@ -1,53 +1,77 @@
-import requests
-from bs4 import BeautifulSoup
 import pathlib
 import re
 
 
 ROOT_PATH = pathlib.Path(__file__).parent.resolve()
-FEED_URL = 'https://github.com/Niketkumardheeryan/Hands-on-ML-Basic-to-Advance-'
+
+
+EXCLUDED_FILES = {
+    ".github",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING_GUIDELINES.md",
+    "build_readme.py",
+    "requirements.txt",
+    "README.md",
+    "download statistics.jpg",
+    "img",
+    "ml img.jpg",
+    ".git",
+    "__pycache__",
+}
+
 
 def replace_chunk(content, marker, chunk, inline=False):
     r = re.compile(
         r"<!\-\- {} start \-\->.*<!\-\- {} end \-\->".format(marker, marker),
         re.DOTALL,
     )
+
     if not inline:
         chunk = "\n{}\n".format(chunk)
-    chunk = "<!-- {} start -->{}<!-- {} end -->".format(marker, chunk, marker)
+
+    chunk = "<!-- {} start -->{}<!-- {} end -->".format(
+        marker,
+        chunk,
+        marker,
+    )
+
     return r.sub(chunk, content)
 
 
+def extract_file_names():
+    temp = []
 
-def Exract_files_names():
-	req = requests.get(FEED_URL)
-	soup = BeautifulSoup(req.text, 'html.parser')
-	temp=[]
-	li = soup.findAll('div', class_="Box-row Box-row--focus-gray py-2 d-flex position-relative js-navigation-item")
-	for i in li:
-		for x in i.findAll('a',class_="js-navigation-open Link--primary"):
-			if(x.text!=".github" and x.text!="CODE_OF_CONDUCT.md" and x.text!="CONTRIBUTING_GUIDELINES.md" and x.text!=".github/workflows" and x.text!="build_readme.py" and x.text!="requirements.txt" and x.text!="README.md" and x.text!="download statistics.jpg" and x.text!="img" and x.text!="ml img.jpg"):
-				temp2={
-                	'fname' : x.text,
-                	'furl': x["href"].split('/')[-1]
-				   		}
-				temp.append(temp2)
-			else:pass
-	return temp
+    for item in ROOT_PATH.iterdir():
+
+        if item.name in EXCLUDED_FILES:
+            continue
+
+        temp.append({
+            "fname": item.name,
+            "furl": item.name
+        })
+
+    return sorted(temp, key=lambda x: x["fname"].lower())
 
 
 if __name__ == "__main__":
-    readme = ROOT_PATH / "README.md"
-    readme_contents = readme.open().read()
 
-    file_names = Exract_files_names()
-    file_md="\n\n".join(["- {}".format(i) for i in file_names])
+    readme = ROOT_PATH / "README.md"
+
+    readme_contents = readme.read_text(encoding="utf-8")
+
+    file_names = extract_file_names()
+
     file_md = "\n".join(
         ["| [{fname}]({furl}) |".format(**i) for i in file_names]
     )
 
-    
-    readme_contents = replace_chunk(readme_contents, "Projects", "| Content List | \n | --------------- | \n" + file_md)
-    readme.open("w").write(readme_contents)
+    updated_content = replace_chunk(
+        readme_contents,
+        "Projects",
+        "| Content List |\n| --------------- |\n" + file_md
+    )
 
+    readme.write_text(updated_content, encoding="utf-8")
 
+    print("README.md updated successfully.")


### PR DESCRIPTION
Description:-

Refactored `build_readme.py` to remove fragile GitHub web scraping and use local filesystem scanning instead.

Changes Made-

* Removed dependency on "requests" and "BeautifulSoup"
* Replaced GitHub DOM scraping with local directory traversal using "pathlib"
* Added excluded file and directory filtering
* Improved robustness and maintainability
* Added sorted project listing generation
* Improved README update handling

Benefits-

* No dependency on GitHub HTML structure
* Faster execution
* More reliable and maintainable
* Works fully offline using local repository files

Fixes #1744
