### PR TITLE
Corrected a spelling error in the project directory name

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,7 +121,7 @@
 | Driver_Drowsiness_Detection | OpenCV, CNN | [View](./Driver_Drowsiness_Detection) |
 | Duplicate_Question_pair | NLP, similarity, Siamese networks | [View](./Duplicate_Question_pair) |
 | Emotion Recognition Based on NLP | NLP, sentiment, classification | [View](./Emotion%20Recognition%20Based%20on%20NLP) |
-| emotion-based music recommendation | NLP, recommendation | [View](./emotion-based%20music%20recommendtion) |
+| emotion-based music recommendation | NLP, recommendation | [View](./emotion-based%20music%20recommendation) |
 | Employee_attrittion_prediction_using_ML | HR analytics, classification | [View](./Employee_attrittion_prediction_using_ML) |
 | Engineering Career Role Prediction | classification, scikit-learn | [View](./Engineering%20Career%20Role%20Prediction) |
 | Face-recognition | OpenCV, face detection | [View](./Face-recognition) |


### PR DESCRIPTION
Corrected a spelling error in the project directory name and updated the corresponding reference in ROADMAP.md.

The folder emotion-based music recommendtion was renamed to emotion-based music recommendation to fix the typo. The broken link in ROADMAP.md was also updated to reflect the correct folder name.

This resolves the broken navigation link in the roadmap.