### PR TITLE
Fix IndexError in Association Rule Implementation notebook

### DIFF
--- a/Association Rule Implementation/19csu207.ipynb
+++ b/Association Rule Implementation/19csu207.ipynb
@@ -150,7 +150,7 @@
     "lift = []\n",
     "association = []\n",
     "for i in range (0, len(results)):\n",
-    "    lift.append(results[:len(results)][i][2][0][3])\n",
+    "    lift.append(results[:len(results)][i][2][0][-1])\n",
     "    association.append(list(results[:len(results)][i][0]))"
    ]
   },


### PR DESCRIPTION
Fixes #1838

### Description
This PR fixes a fatal `IndexError` in `Association Rule Implementation/19csu207.ipynb`. The apriori results list processing was crashing due to an out-of-bounds index when attempting to extract the `lift` variable.

### Changes Made
- Updated the tuple indexing logic from hardcoded `[3]` to `[-1]` when appending the lift results.
- This ensures the notebook can extract the necessary confidence/lift metrics without crashing on dimension mismatches.