### PR TITLE
Bug :fix - resolve startup error and image upload stream handling

### DIFF
--- a/Brain Tumor Detection/Web App/app.py
+++ b/Brain Tumor Detection/Web App/app.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, render_template, request
 import numpy as np
 import tensorflow as tf
@@ -37,15 +38,36 @@ def index():
 def predict():
     try:
         image = request.files['image']
-        img = Image.open(image.stream)
-        img = preprocess_image(img)
+
+        # Read uploaded image only once
+        image_bytes = image.read()
+
+        # Create image object for display
+        img_pil = Image.open(io.BytesIO(image_bytes))
+
+        # Create separate image object for model preprocessing
+        img = preprocess_image(
+            Image.open(io.BytesIO(image_bytes))
+        )
+
         predictions = model.predict(img)
         predicted_class = np.argmax(predictions)
         predicted_label = class_labels[predicted_class]
-        img_base64 = image_to_base64(Image.open(image.stream))
-        return render_template('result.html', description=predicted_label, image_data=img_base64)
+
+        # Convert uploaded image to base64 for rendering
+        img_base64 = image_to_base64(img_pil)
+
+        return render_template(
+            'result.html',
+            description=predicted_label,
+            image_data=img_base64
+        )
+
     except Exception as e:
-        return render_template('error.html', error_message=str(e))
+        return render_template(
+            'error.html',
+            error_message=str(e)
+        )
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
### Changes Made

* Added the missing `os` import to prevent a startup `NameError` in `load_model_and_labels()`.
* Fixed the image upload logic by reading the uploaded image once and reusing it for both prediction and base64 conversion.
* Resolved the stream exhaustion issue caused by reading `image.stream` multiple times.
* Improved the reliability of the `/predict` endpoint for uploaded images.

Fixes #1857 

If the changes meet the project requirements, kindly consider merging this PR. Also, please add the **GSSoC'26** label before merging so the contribution can be tracked properly.

Thank you for your review!
