### PR TITLE
docs: Add classification metrics documentation to Basics of ML and DL

### DIFF
--- a/Basics of ML and DL/ML/ClassificationMetrics.ipynb
+++ b/Basics of ML and DL/ML/ClassificationMetrics.ipynb
@@ -1,165 +1,133 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Classification Metrics in Machine Learning\n\nWhen you train a classifier, accuracy alone doesn't tell the whole story, especially on imbalanced datasets. This notebook covers the five most important classification metrics:\n\n1. **Confusion Matrix** - the foundation everything else is built on\n2. **Accuracy** - overall correctness\n3. **Precision** - how trustworthy positive predictions are\n4. **Recall** - how many actual positives were caught\n5. **F1 Score** - balance between precision and recall\n\nWe'll use the Iris dataset with a Logistic Regression classifier to demonstrate each one."
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn import datasets\n",
     "from sklearn.linear_model import LogisticRegression\n",
-    "from sklearn.model_selection import train_test_split"
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import confusion_matrix, classification_report, accuracy_score\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset & Model Setup\n",
+    "\n",
+    "The Iris dataset has 150 samples across 3 classes (Setosa, Versicolor, Virginica). We split it 75/25 into train and test sets, then fit a Logistic Regression classifier."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "iris = datasets.load_iris()"
+    "iris = datasets.load_iris()\n",
+    "\n",
+    "x_train, x_test, y_train, y_test = train_test_split(\n",
+    "    iris.data, iris.target, random_state=1\n",
+    ")\n",
+    "\n",
+    "clf = LogisticRegression(max_iter=200)\n",
+    "clf.fit(x_train, y_train)\n",
+    "\n",
+    "y_train_pred = clf.predict(x_train)\n",
+    "y_test_pred  = clf.predict(x_test)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\n## 1. Confusion Matrix\n\nA confusion matrix lays out every combination of actual vs. predicted class in a grid. For a binary classifier the four cells are:\n\n| | Predicted Positive | Predicted Negative |\n|---|---|---|\n| **Actual Positive** | True Positive (TP) | False Negative (FN) |\n| **Actual Negative** | False Positive (FP) | True Negative (TN) |\n\n- **TP** - model correctly predicted positive  \n- **TN** - model correctly predicted negative  \n- **FP** - model predicted positive, but it was actually negative (Type I error)  \n- **FN** - model predicted negative, but it was actually positive (Type II error)  \n\nFor multi-class problems (like Iris with 3 classes), the matrix extends to N x N where each row is the actual class and each column is the predicted class. A perfect classifier has all values on the diagonal."
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "x_train, x_test, y_train, y_test = train_test_split(iris.data, iris.target, random_state=1)"
-   ]
+   "source": "cm = confusion_matrix(y_test, y_test_pred)\n\nplt.figure(figsize=(6, 4))\nsns.heatmap(cm, annot=True, fmt='d', cmap='Blues',\n            xticklabels=iris.target_names,\n            yticklabels=iris.target_names)\nplt.ylabel('Actual')\nplt.xlabel('Predicted')\nplt.title('Confusion Matrix - Test Set')\nplt.tight_layout()\nplt.show()\n\nprint(cm)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\n## 2. Accuracy\n\nAccuracy is the simplest metric - the fraction of all predictions that were correct.\n\n$$\\text{Accuracy} = \\frac{TP + TN}{TP + TN + FP + FN}$$\n\n**When to use it:** Only reliable when classes are roughly balanced. A model that predicts the majority class every time on a 95/5 split achieves 95% accuracy without learning anything useful.\n\n**When to avoid it:** Imbalanced datasets (fraud detection, disease screening)."
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
-       "          intercept_scaling=1, max_iter=100, multi_class='ovr', n_jobs=1,\n",
-       "          penalty='l2', random_state=None, solver='liblinear', tol=0.0001,\n",
-       "          verbose=0, warm_start=False)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "clf = LogisticRegression()\n",
-    "clf.fit(x_train, y_train)"
+    "acc = accuracy_score(y_test, y_test_pred)\n",
+    "print(f\"Test Accuracy: {acc:.4f}  ({acc*100:.2f}%)\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Precision\n",
+    "\n",
+    "Precision answers: *\"Of all the samples the model labeled as positive, how many actually were positive?\"*\n",
+    "\n",
+    "$$\\text{Precision} = \\frac{TP}{TP + FP}$$\n",
+    "\n",
+    "**High precision matters when** false positives are costly — e.g., spam filtering (you don't want to delete real emails), or medical tests that lead to invasive procedures.\n",
+    "\n",
+    "A model that is very conservative and only predicts positive when it's very sure will have high precision, but may miss many actual positives."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Recall (Sensitivity)\n",
+    "\n",
+    "Recall answers: *\"Of all the actual positives, how many did the model find?\"*\n",
+    "\n",
+    "$$\\text{Recall} = \\frac{TP}{TP + FN}$$\n",
+    "\n",
+    "Also called **sensitivity** or **true positive rate**.\n",
+    "\n",
+    "**High recall matters when** false negatives are costly — e.g., cancer screening (you really don't want to miss a positive case), fraud detection (missing a fraudulent transaction is worse than a false alarm).\n",
+    "\n",
+    "A model that predicts positive for everything will have 100% recall but terrible precision."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\n## 5. F1 Score\n\nPrecision and recall trade off against each other. The F1 score is their **harmonic mean**, giving a single number that balances both.\n\n$$\\text{F1} = 2 \\times \\frac{\\text{Precision} \\times \\text{Recall}}{\\text{Precision} + \\text{Recall}}$$\n\nThe harmonic mean penalises extreme imbalances - if either precision or recall is very low, F1 will be low too. A perfect F1 score is 1.0, and the worst is 0.0.\n\n**When to use it:** Whenever you need a single metric that respects both false positives and false negatives, especially on imbalanced datasets.\n\n### Precision-Recall Trade-off Summary\n\n| Scenario | Prioritise |\n|---|---|\n| Spam filter | Precision (avoid deleting real emails) |\n| Cancer screening | Recall (avoid missing cases) |\n| General imbalanced data | F1 Score |"
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "y_train_pred = clf.predict(x_train)"
+    "# classification_report prints precision, recall, and F1 for every class\n",
+    "print(classification_report(y_test, y_test_pred, target_names=iris.target_names))"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "y_test_pred = clf.predict(x_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from sklearn.metrics import confusion_matrix"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[37,  0,  0],\n",
-       "       [ 0, 28,  6],\n",
-       "       [ 0,  0, 41]])"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "confusion_matrix(y_train, y_train_pred)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[13,  0,  0],\n",
-       "       [ 0, 10,  6],\n",
-       "       [ 0,  0,  9]])"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "confusion_matrix(y_test, y_test_pred)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "             precision    recall  f1-score   support\n",
-      "\n",
-      "          0       1.00      1.00      1.00        13\n",
-      "          1       1.00      0.62      0.77        16\n",
-      "          2       0.60      1.00      0.75         9\n",
-      "\n",
-      "avg / total       0.91      0.84      0.84        38\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "from sklearn.metrics import classification_report\n",
-    "print(classification_report(y_test, y_test_pred))"
-   ]
+   "source": "### Reading the Report\n\n- **precision** - per-class precision\n- **recall** - per-class recall  \n- **f1-score** - per-class F1\n- **support** - number of actual samples in that class\n- **macro avg** - unweighted mean across classes (treats all classes equally)\n- **weighted avg** - mean weighted by support (accounts for class imbalance)\n\nLooking at the output above, class 1 (*Versicolor*) has lower recall because some of its samples were misclassified as class 2 (*Virginica*), visible as off-diagonal entries in the confusion matrix."
   }
  ],
  "metadata": {
@@ -176,7 +144,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
+   "nbformat_minor": 2,
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
   }


### PR DESCRIPTION
## Summary

- Added markdown documentation to `Basics of ML and DL/ML/ClassificationMetrics.ipynb` covering the five core classification evaluation metrics
- Each metric includes an explanation, formula, and guidance on when to use it
- Added a heatmap visualization of the confusion matrix using seaborn

## Metrics Covered

1. **Confusion Matrix** - TP/TN/FP/FN breakdown with an N×N heatmap for multi-class
2. **Accuracy** - formula + when it breaks down on imbalanced data
3. **Precision** - formula + false positive cost trade-off
4. **Recall** - formula + false negative cost trade-off
5. **F1 Score** - harmonic mean with a precision/recall trade-off summary table

## Related Issue

Closes #783

---