### PR TITLE
feat: Add explainable loan default risk prediction dashboard

### DIFF
--- a/Explainable Loan Default Risk Prediction/Explainable_Loan_Default_Risk_Prediction.ipynb
+++ b/Explainable Loan Default Risk Prediction/Explainable_Loan_Default_Risk_Prediction.ipynb
@@ -1,0 +1,426 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Explainable Loan Default Risk Prediction\n",
+    "\n",
+    "This notebook trains and explains a loan default risk classifier using a synthetic applicant dataset. It mirrors the project workflow from data generation through model comparison, prediction, and SHAP-based explanation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.metrics import accuracy_score, confusion_matrix, f1_score, precision_score, recall_score, roc_auc_score\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OneHotEncoder, StandardScaler\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "RANDOM_STATE = 42"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Generate Synthetic Loan Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUMERIC_FEATURES = [\n",
+    "    \"age\",\n",
+    "    \"annual_income\",\n",
+    "    \"employment_length_years\",\n",
+    "    \"loan_amount\",\n",
+    "    \"loan_term_months\",\n",
+    "    \"interest_rate\",\n",
+    "    \"debt_to_income_ratio\",\n",
+    "    \"credit_score\",\n",
+    "    \"credit_history_years\",\n",
+    "    \"previous_missed_payments\",\n",
+    "]\n",
+    "\n",
+    "CATEGORICAL_FEATURES = [\n",
+    "    \"employment_status\",\n",
+    "    \"education_level\",\n",
+    "    \"loan_purpose\",\n",
+    "    \"property_area\",\n",
+    "]\n",
+    "\n",
+    "TARGET_COLUMN = \"default\"\n",
+    "\n",
+    "\n",
+    "def build_dataset(n_samples=1200, random_state=RANDOM_STATE):\n",
+    "    rng = np.random.default_rng(random_state)\n",
+    "\n",
+    "    age = rng.integers(21, 68, n_samples)\n",
+    "    annual_income = rng.lognormal(mean=10.9, sigma=0.45, size=n_samples).clip(18000, 220000)\n",
+    "    employment_length = rng.integers(0, 28, n_samples)\n",
+    "    loan_amount = rng.lognormal(mean=10.2, sigma=0.5, size=n_samples).clip(2500, 85000)\n",
+    "    loan_term = rng.choice([36, 48, 60, 84], size=n_samples, p=[0.38, 0.2, 0.34, 0.08])\n",
+    "    credit_score = rng.normal(680, 72, n_samples).clip(300, 850)\n",
+    "    credit_history = rng.integers(1, 31, n_samples)\n",
+    "    missed_payments = rng.poisson(0.35, n_samples).clip(0, 6)\n",
+    "    debt_to_income = (loan_amount / annual_income * 0.55 + rng.normal(0.18, 0.08, n_samples)).clip(0.02, 0.75)\n",
+    "    interest_rate = (\n",
+    "        0.07\n",
+    "        + (760 - credit_score) / 3000\n",
+    "        + debt_to_income * 0.08\n",
+    "        + missed_payments * 0.01\n",
+    "        + rng.normal(0, 0.012, n_samples)\n",
+    "    ).clip(0.045, 0.29)\n",
+    "\n",
+    "    employment_status = rng.choice([\"Full-time\", \"Part-time\", \"Self-employed\", \"Unemployed\"], n_samples, p=[0.58, 0.16, 0.18, 0.08])\n",
+    "    education_level = rng.choice([\"High School\", \"Bachelor\", \"Master\", \"Doctorate\"], n_samples, p=[0.32, 0.43, 0.2, 0.05])\n",
+    "    loan_purpose = rng.choice([\"Debt consolidation\", \"Home improvement\", \"Medical\", \"Education\", \"Business\"], n_samples, p=[0.42, 0.2, 0.12, 0.14, 0.12])\n",
+    "    property_area = rng.choice([\"Urban\", \"Semiurban\", \"Rural\"], n_samples, p=[0.48, 0.32, 0.2])\n",
+    "\n",
+    "    logits = (\n",
+    "        -2.4\n",
+    "        + debt_to_income * 3.2\n",
+    "        + (loan_amount / annual_income) * 1.7\n",
+    "        + (680 - credit_score) / 95\n",
+    "        + missed_payments * 0.55\n",
+    "        + (interest_rate - 0.11) * 5.0\n",
+    "        - employment_length * 0.025\n",
+    "        - credit_history * 0.018\n",
+    "    )\n",
+    "    logits += np.where(employment_status == \"Unemployed\", 0.8, 0)\n",
+    "    logits += np.where(employment_status == \"Part-time\", 0.25, 0)\n",
+    "    logits += np.where(loan_purpose == \"Business\", 0.22, 0)\n",
+    "    logits += np.where(property_area == \"Rural\", 0.12, 0)\n",
+    "\n",
+    "    default_probability = 1 / (1 + np.exp(-logits))\n",
+    "    default = rng.binomial(1, default_probability)\n",
+    "\n",
+    "    return pd.DataFrame({\n",
+    "        \"age\": age,\n",
+    "        \"annual_income\": annual_income.round(2),\n",
+    "        \"employment_length_years\": employment_length,\n",
+    "        \"loan_amount\": loan_amount.round(2),\n",
+    "        \"loan_term_months\": loan_term,\n",
+    "        \"interest_rate\": interest_rate.round(4),\n",
+    "        \"debt_to_income_ratio\": debt_to_income.round(3),\n",
+    "        \"credit_score\": credit_score.round().astype(int),\n",
+    "        \"credit_history_years\": credit_history,\n",
+    "        \"previous_missed_payments\": missed_payments,\n",
+    "        \"employment_status\": employment_status,\n",
+    "        \"education_level\": education_level,\n",
+    "        \"loan_purpose\": loan_purpose,\n",
+    "        \"property_area\": property_area,\n",
+    "        \"default\": default,\n",
+    "    })\n",
+    "\n",
+    "\n",
+    "data = build_dataset()\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data[TARGET_COLUMN].value_counts(normalize=True).rename(\"class_share\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Build Preprocessing and Model Pipelines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_preprocessor():\n",
+    "    numeric_pipeline = Pipeline([\n",
+    "        (\"imputer\", SimpleImputer(strategy=\"median\")),\n",
+    "        (\"scaler\", StandardScaler()),\n",
+    "    ])\n",
+    "\n",
+    "    categorical_pipeline = Pipeline([\n",
+    "        (\"imputer\", SimpleImputer(strategy=\"most_frequent\")),\n",
+    "        (\"encoder\", OneHotEncoder(handle_unknown=\"ignore\")),\n",
+    "    ])\n",
+    "\n",
+    "    return ColumnTransformer([\n",
+    "        (\"numeric\", numeric_pipeline, NUMERIC_FEATURES),\n",
+    "        (\"categorical\", categorical_pipeline, CATEGORICAL_FEATURES),\n",
+    "    ])\n",
+    "\n",
+    "\n",
+    "def make_models():\n",
+    "    return {\n",
+    "        \"Logistic Regression\": Pipeline([\n",
+    "            (\"preprocessor\", make_preprocessor()),\n",
+    "            (\"classifier\", LogisticRegression(max_iter=1000, class_weight=\"balanced\")),\n",
+    "        ]),\n",
+    "        \"Random Forest\": Pipeline([\n",
+    "            (\"preprocessor\", make_preprocessor()),\n",
+    "            (\"classifier\", RandomForestClassifier(n_estimators=220, max_depth=10, class_weight=\"balanced\", random_state=RANDOM_STATE)),\n",
+    "        ]),\n",
+    "        \"Gradient Boosting\": Pipeline([\n",
+    "            (\"preprocessor\", make_preprocessor()),\n",
+    "            (\"classifier\", GradientBoostingClassifier(random_state=RANDOM_STATE)),\n",
+    "        ]),\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Train and Compare Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = data[NUMERIC_FEATURES + CATEGORICAL_FEATURES]\n",
+    "y = data[TARGET_COLUMN]\n",
+    "\n",
+    "x_train, x_test, y_train, y_test = train_test_split(\n",
+    "    x,\n",
+    "    y,\n",
+    "    test_size=0.2,\n",
+    "    random_state=RANDOM_STATE,\n",
+    "    stratify=y,\n",
+    ")\n",
+    "\n",
+    "models = make_models()\n",
+    "rows = []\n",
+    "confusion_matrices = {}\n",
+    "\n",
+    "for name, model in models.items():\n",
+    "    model.fit(x_train, y_train)\n",
+    "    predictions = model.predict(x_test)\n",
+    "    probabilities = model.predict_proba(x_test)[:, 1]\n",
+    "    confusion_matrices[name] = confusion_matrix(y_test, predictions)\n",
+    "    rows.append({\n",
+    "        \"model\": name,\n",
+    "        \"accuracy\": accuracy_score(y_test, predictions),\n",
+    "        \"precision\": precision_score(y_test, predictions, zero_division=0),\n",
+    "        \"recall\": recall_score(y_test, predictions, zero_division=0),\n",
+    "        \"f1_score\": f1_score(y_test, predictions, zero_division=0),\n",
+    "        \"roc_auc\": roc_auc_score(y_test, probabilities),\n",
+    "    })\n",
+    "\n",
+    "metrics = pd.DataFrame(rows).sort_values(\"roc_auc\", ascending=False).reset_index(drop=True)\n",
+    "best_model_name = metrics.loc[0, \"model\"]\n",
+    "best_model = models[best_model_name]\n",
+    "\n",
+    "metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_model_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Visualize the Best Model Confusion Matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matrix = confusion_matrices[best_model_name]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(4, 3))\n",
+    "ax.imshow(matrix, cmap=\"Blues\")\n",
+    "ax.set_xticks([0, 1], labels=[\"No Default\", \"Default\"])\n",
+    "ax.set_yticks([0, 1], labels=[\"No Default\", \"Default\"])\n",
+    "ax.set_xlabel(\"Predicted\")\n",
+    "ax.set_ylabel(\"Actual\")\n",
+    "ax.set_title(f\"Confusion Matrix: {best_model_name}\")\n",
+    "\n",
+    "for row in range(2):\n",
+    "    for col in range(2):\n",
+    "        ax.text(col, row, int(matrix[row, col]), ha=\"center\", va=\"center\", color=\"black\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Predict Risk for a New Applicant"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_applicant = {\n",
+    "    \"age\": 36,\n",
+    "    \"annual_income\": 62000,\n",
+    "    \"employment_length_years\": 6,\n",
+    "    \"loan_amount\": 18000,\n",
+    "    \"loan_term_months\": 60,\n",
+    "    \"interest_rate\": 0.13,\n",
+    "    \"debt_to_income_ratio\": 0.28,\n",
+    "    \"credit_score\": 690,\n",
+    "    \"credit_history_years\": 9,\n",
+    "    \"previous_missed_payments\": 0,\n",
+    "    \"employment_status\": \"Full-time\",\n",
+    "    \"education_level\": \"Bachelor\",\n",
+    "    \"loan_purpose\": \"Debt consolidation\",\n",
+    "    \"property_area\": \"Urban\",\n",
+    "}\n",
+    "\n",
+    "def risk_tier(probability):\n",
+    "    if probability >= 0.65:\n",
+    "        return \"High\"\n",
+    "    if probability >= 0.35:\n",
+    "        return \"Medium\"\n",
+    "    return \"Low\"\n",
+    "\n",
+    "sample_frame = pd.DataFrame([sample_applicant])\n",
+    "default_probability = best_model.predict_proba(sample_frame)[0, 1]\n",
+    "\n",
+    "pd.DataFrame({\n",
+    "    \"default_probability\": [default_probability],\n",
+    "    \"risk_tier\": [risk_tier(default_probability)],\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Explain Prediction with SHAP\n",
+    "\n",
+    "Run this cell after installing `shap`. The notebook keeps SHAP optional so the core model workflow can run in lighter environments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import shap\n",
+    "\n",
+    "    preprocessor = best_model.named_steps[\"preprocessor\"]\n",
+    "    classifier = best_model.named_steps[\"classifier\"]\n",
+    "    feature_names = list(preprocessor.get_feature_names_out())\n",
+    "\n",
+    "    transformed_train = preprocessor.transform(x_train)\n",
+    "    transformed_sample = preprocessor.transform(sample_frame)\n",
+    "\n",
+    "    if hasattr(transformed_train, \"toarray\"):\n",
+    "        transformed_train = transformed_train.toarray()\n",
+    "    if hasattr(transformed_sample, \"toarray\"):\n",
+    "        transformed_sample = transformed_sample.toarray()\n",
+    "\n",
+    "    if best_model_name in {\"Random Forest\", \"Gradient Boosting\"}:\n",
+    "        explainer = shap.TreeExplainer(classifier)\n",
+    "        shap_values = explainer.shap_values(transformed_sample)\n",
+    "        if isinstance(shap_values, list):\n",
+    "            shap_values = shap_values[1]\n",
+    "        elif getattr(shap_values, \"ndim\", 0) == 3:\n",
+    "            shap_values = shap_values[:, :, 1]\n",
+    "    else:\n",
+    "        explainer = shap.Explainer(classifier, transformed_train[:100])\n",
+    "        shap_values = explainer(transformed_sample).values\n",
+    "\n",
+    "    contributions = pd.DataFrame({\n",
+    "        \"feature\": feature_names,\n",
+    "        \"contribution\": shap_values[0],\n",
+    "    })\n",
+    "    contributions[\"absolute_contribution\"] = contributions[\"contribution\"].abs()\n",
+    "    top_contributions = contributions.sort_values(\"absolute_contribution\", ascending=False).head(12)\n",
+    "    display(top_contributions[[\"feature\", \"contribution\"]])\n",
+    "\n",
+    "    ax = top_contributions.sort_values(\"contribution\").plot.barh(x=\"feature\", y=\"contribution\", figsize=(8, 5), legend=False)\n",
+    "    ax.set_title(\"Top Local SHAP Contributions\")\n",
+    "    ax.set_xlabel(\"Contribution to Default Risk\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "except ImportError:\n",
+    "    print(\"Install shap to run this explanation cell: pip install shap\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "This notebook is for education and experimentation only. It should not be used for real credit decisions without validated real-world data, fairness checks, compliance review, and ongoing monitoring."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Explainable Loan Default Risk Prediction/README.md
+++ b/Explainable Loan Default Risk Prediction/README.md
@@ -1,0 +1,101 @@
+# Explainable Loan Default Risk Prediction System
+
+This project predicts whether a loan applicant is likely to default and explains the prediction with SHAP values. It includes a complete tabular machine learning workflow and an interactive Streamlit dashboard for risk scoring.
+
+## Features
+
+- Synthetic loan applicant dataset generation for reproducible demos
+- Data loading and preprocessing with missing-value handling
+- Categorical encoding and numeric scaling through scikit-learn pipelines
+- Logistic Regression, Random Forest, and Gradient Boosting model comparison
+- Accuracy, precision, recall, F1-score, ROC-AUC, and confusion matrix reporting
+- SHAP-based global feature importance and local prediction explanations
+- Streamlit dashboard for applicant input, risk category, and feature contributions
+
+## Project Structure
+
+```text
+Explainable Loan Default Risk Prediction/
+├── app.py
+├── requirements.txt
+├── README.md
+└── src/
+    └── loan_default_pipeline.py
+```
+
+## Dataset
+
+The project generates a realistic synthetic loan dataset when no CSV is provided. The generated data contains borrower and loan attributes such as age, income, employment length, loan amount, interest rate, debt-to-income ratio, credit history, missed payments, employment status, education level, loan purpose, and property area.
+
+Target column:
+
+- `default`: `1` for likely default, `0` for non-default
+
+You can replace the synthetic data with a real CSV by updating `DATA_PATH` in `app.py` or importing the helpers from `src/loan_default_pipeline.py`.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run The Dashboard
+
+```bash
+streamlit run app.py
+```
+
+## Train And Evaluate From Python
+
+```python
+from src.loan_default_pipeline import build_dataset, train_models
+
+data = build_dataset()
+result = train_models(data)
+
+print(result.metrics)
+print(result.best_model_name)
+```
+
+## Workflow
+
+1. Generate or load loan applicant data.
+2. Split the dataset into train and test sets.
+3. Impute missing values, scale numeric columns, and one-hot encode categorical columns.
+4. Train Logistic Regression, Random Forest, and Gradient Boosting models.
+5. Select the best model using ROC-AUC.
+6. Explain global model behavior and individual predictions with SHAP.
+7. Serve the selected model through a Streamlit dashboard.
+
+## Model Evaluation
+
+The training pipeline reports:
+
+- Accuracy
+- Precision
+- Recall
+- F1-score
+- ROC-AUC
+- Confusion matrix
+
+These metrics are suitable for a binary financial risk classification problem where false negatives and false positives both matter.
+
+## SHAP Explainability
+
+The dashboard shows:
+
+- Top global drivers of default risk
+- Applicant-specific feature contribution chart
+- Default probability and risk tier
+
+For tree-based models, SHAP values are calculated using `shap.TreeExplainer`. For Logistic Regression, the project uses `shap.Explainer` over the transformed feature matrix.
+
+## Risk Tiers
+
+- Low Risk: default probability below `0.35`
+- Medium Risk: default probability from `0.35` to `0.65`
+- High Risk: default probability above `0.65`
+
+## Notes
+
+This project is intended for education and experimentation. It should not be used for real credit decisions without validated real-world data, fairness checks, compliance review, and monitoring.

--- a/Explainable Loan Default Risk Prediction/app.py
+++ b/Explainable Loan Default Risk Prediction/app.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import shap
+import streamlit as st
+
+from src.loan_default_pipeline import (
+    CATEGORICAL_FEATURES,
+    NUMERIC_FEATURES,
+    get_feature_names,
+    load_or_build_dataset,
+    predict_default,
+    train_models,
+)
+
+
+st.set_page_config(
+    page_title="Loan Default Risk",
+    layout="wide",
+)
+
+
+@st.cache_data
+def load_data() -> pd.DataFrame:
+    return load_or_build_dataset()
+
+
+@st.cache_resource
+def train_cached(data: pd.DataFrame):
+    return train_models(data)
+
+
+def build_applicant_form(data: pd.DataFrame) -> dict[str, object]:
+    st.sidebar.header("Applicant Details")
+    applicant: dict[str, object] = {}
+
+    applicant["age"] = st.sidebar.slider("Age", 21, 70, 36)
+    applicant["annual_income"] = st.sidebar.number_input("Annual income", 15000, 250000, 62000, step=1000)
+    applicant["employment_length_years"] = st.sidebar.slider("Employment length", 0, 35, 6)
+    applicant["loan_amount"] = st.sidebar.number_input("Loan amount", 1000, 100000, 18000, step=500)
+    applicant["loan_term_months"] = st.sidebar.selectbox("Loan term", [36, 48, 60, 84], index=2)
+    applicant["interest_rate"] = st.sidebar.slider("Interest rate", 0.04, 0.3, 0.13, step=0.005)
+    applicant["debt_to_income_ratio"] = st.sidebar.slider("Debt-to-income ratio", 0.02, 0.8, 0.28, step=0.01)
+    applicant["credit_score"] = st.sidebar.slider("Credit score", 300, 850, 690)
+    applicant["credit_history_years"] = st.sidebar.slider("Credit history years", 1, 35, 9)
+    applicant["previous_missed_payments"] = st.sidebar.slider("Previous missed payments", 0, 8, 0)
+
+    for feature in CATEGORICAL_FEATURES:
+        values = sorted(data[feature].dropna().unique().tolist())
+        applicant[feature] = st.sidebar.selectbox(feature.replace("_", " ").title(), values)
+
+    return applicant
+
+
+def plot_confusion_matrix(matrix):
+    fig, ax = plt.subplots(figsize=(4, 3))
+    ax.imshow(matrix, cmap="Blues")
+    ax.set_xticks([0, 1], labels=["No Default", "Default"])
+    ax.set_yticks([0, 1], labels=["No Default", "Default"])
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("Actual")
+
+    for row in range(2):
+        for col in range(2):
+            ax.text(col, row, int(matrix[row, col]), ha="center", va="center", color="black")
+
+    fig.tight_layout()
+    return fig
+
+
+def calculate_shap_values(result, applicant: dict[str, object]):
+    model = result.model
+    preprocessor = model.named_steps["preprocessor"]
+    classifier = model.named_steps["classifier"]
+    feature_names = get_feature_names(model)
+
+    transformed_train = preprocessor.transform(result.x_train)
+    transformed_applicant = preprocessor.transform(pd.DataFrame([applicant]))
+
+    if hasattr(transformed_train, "toarray"):
+        transformed_train = transformed_train.toarray()
+    if hasattr(transformed_applicant, "toarray"):
+        transformed_applicant = transformed_applicant.toarray()
+
+    if result.best_model_name in {"Random Forest", "Gradient Boosting"}:
+        explainer = shap.TreeExplainer(classifier)
+        shap_values = explainer.shap_values(transformed_applicant)
+        if isinstance(shap_values, list):
+            shap_values = shap_values[1]
+        elif getattr(shap_values, "ndim", 0) == 3:
+            shap_values = shap_values[:, :, 1]
+    else:
+        background = transformed_train[:100]
+        explainer = shap.Explainer(classifier, background)
+        shap_values = explainer(transformed_applicant).values
+
+    contributions = pd.DataFrame(
+        {
+            "feature": feature_names,
+            "contribution": shap_values[0],
+        }
+    )
+    contributions["absolute_contribution"] = contributions["contribution"].abs()
+    return contributions.sort_values("absolute_contribution", ascending=False).head(12)
+
+
+data = load_data()
+result = train_cached(data)
+applicant = build_applicant_form(data)
+probability, risk = predict_default(result.model, applicant)
+
+st.title("Explainable Loan Default Risk Prediction")
+
+score_col, risk_col, model_col = st.columns(3)
+score_col.metric("Default Probability", f"{probability:.1%}")
+risk_col.metric("Risk Category", risk)
+model_col.metric("Selected Model", result.best_model_name)
+
+metrics_tab, prediction_tab, explain_tab, data_tab = st.tabs(
+    ["Model Metrics", "Prediction", "SHAP Explainability", "Dataset"]
+)
+
+with metrics_tab:
+    st.subheader("Model Comparison")
+    st.dataframe(result.metrics, use_container_width=True)
+
+    st.subheader("Confusion Matrix")
+    st.pyplot(plot_confusion_matrix(result.confusion_matrices[result.best_model_name]))
+
+with prediction_tab:
+    st.subheader("Applicant Summary")
+    applicant_frame = pd.DataFrame([applicant])[NUMERIC_FEATURES + CATEGORICAL_FEATURES]
+    st.dataframe(applicant_frame, use_container_width=True)
+
+    if risk == "High":
+        st.error("This applicant has a high estimated default risk.")
+    elif risk == "Medium":
+        st.warning("This applicant has a medium estimated default risk.")
+    else:
+        st.success("This applicant has a low estimated default risk.")
+
+with explain_tab:
+    st.subheader("Top Local SHAP Contributions")
+    contributions = calculate_shap_values(result, applicant)
+    st.bar_chart(contributions.set_index("feature")["contribution"])
+    st.dataframe(contributions[["feature", "contribution"]], use_container_width=True)
+
+    st.subheader("Global Feature Importance")
+    preprocessor = result.model.named_steps["preprocessor"]
+    classifier = result.model.named_steps["classifier"]
+    feature_names = get_feature_names(result.model)
+
+    if hasattr(classifier, "feature_importances_"):
+        global_importance = pd.DataFrame(
+            {
+                "feature": feature_names,
+                "importance": classifier.feature_importances_,
+            }
+        ).sort_values("importance", ascending=False).head(12)
+        st.bar_chart(global_importance.set_index("feature")["importance"])
+    else:
+        st.info("Global feature importance is shown for tree-based models. Local SHAP values are available above.")
+
+with data_tab:
+    st.subheader("Training Dataset Preview")
+    st.dataframe(data.head(25), use_container_width=True)
+    st.write(f"Rows: {len(data):,}")

--- a/Explainable Loan Default Risk Prediction/requirements.txt
+++ b/Explainable Loan Default Risk Prediction/requirements.txt
@@ -1,0 +1,7 @@
+pandas>=2.0.0
+numpy>=1.24.0
+scikit-learn>=1.3.0
+matplotlib>=3.7.0
+seaborn>=0.12.0
+shap>=0.44.0
+streamlit>=1.32.0

--- a/Explainable Loan Default Risk Prediction/src/loan_default_pipeline.py
+++ b/Explainable Loan Default Risk Prediction/src/loan_default_pipeline.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import (
+    accuracy_score,
+    confusion_matrix,
+    f1_score,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+
+NUMERIC_FEATURES = [
+    "age",
+    "annual_income",
+    "employment_length_years",
+    "loan_amount",
+    "loan_term_months",
+    "interest_rate",
+    "debt_to_income_ratio",
+    "credit_score",
+    "credit_history_years",
+    "previous_missed_payments",
+]
+
+CATEGORICAL_FEATURES = [
+    "employment_status",
+    "education_level",
+    "loan_purpose",
+    "property_area",
+]
+
+TARGET_COLUMN = "default"
+
+
+@dataclass
+class TrainingResult:
+    best_model_name: str
+    model: Pipeline
+    metrics: pd.DataFrame
+    confusion_matrices: dict[str, np.ndarray]
+    x_train: pd.DataFrame
+    x_test: pd.DataFrame
+    y_train: pd.Series
+    y_test: pd.Series
+
+
+def build_dataset(n_samples: int = 1200, random_state: int = 42) -> pd.DataFrame:
+    """Create a reproducible loan-default dataset for demos and local training."""
+    rng = np.random.default_rng(random_state)
+
+    age = rng.integers(21, 68, n_samples)
+    annual_income = rng.lognormal(mean=10.9, sigma=0.45, size=n_samples).clip(18000, 220000)
+    employment_length = rng.integers(0, 28, n_samples)
+    loan_amount = rng.lognormal(mean=10.2, sigma=0.5, size=n_samples).clip(2500, 85000)
+    loan_term = rng.choice([36, 48, 60, 84], size=n_samples, p=[0.38, 0.2, 0.34, 0.08])
+    credit_score = rng.normal(680, 72, n_samples).clip(300, 850)
+    credit_history = rng.integers(1, 31, n_samples)
+    missed_payments = rng.poisson(0.35, n_samples).clip(0, 6)
+    debt_to_income = (loan_amount / annual_income * 0.55 + rng.normal(0.18, 0.08, n_samples)).clip(0.02, 0.75)
+    interest_rate = (
+        0.07
+        + (760 - credit_score) / 3000
+        + debt_to_income * 0.08
+        + missed_payments * 0.01
+        + rng.normal(0, 0.012, n_samples)
+    ).clip(0.045, 0.29)
+
+    employment_status = rng.choice(
+        ["Full-time", "Part-time", "Self-employed", "Unemployed"],
+        n_samples,
+        p=[0.58, 0.16, 0.18, 0.08],
+    )
+    education_level = rng.choice(
+        ["High School", "Bachelor", "Master", "Doctorate"],
+        n_samples,
+        p=[0.32, 0.43, 0.2, 0.05],
+    )
+    loan_purpose = rng.choice(
+        ["Debt consolidation", "Home improvement", "Medical", "Education", "Business"],
+        n_samples,
+        p=[0.42, 0.2, 0.12, 0.14, 0.12],
+    )
+    property_area = rng.choice(["Urban", "Semiurban", "Rural"], n_samples, p=[0.48, 0.32, 0.2])
+
+    logits = (
+        -2.4
+        + debt_to_income * 3.2
+        + (loan_amount / annual_income) * 1.7
+        + (680 - credit_score) / 95
+        + missed_payments * 0.55
+        + (interest_rate - 0.11) * 5.0
+        - employment_length * 0.025
+        - credit_history * 0.018
+    )
+    logits += np.where(employment_status == "Unemployed", 0.8, 0)
+    logits += np.where(employment_status == "Part-time", 0.25, 0)
+    logits += np.where(loan_purpose == "Business", 0.22, 0)
+    logits += np.where(property_area == "Rural", 0.12, 0)
+
+    default_probability = 1 / (1 + np.exp(-logits))
+    default = rng.binomial(1, default_probability)
+
+    return pd.DataFrame(
+        {
+            "age": age,
+            "annual_income": annual_income.round(2),
+            "employment_length_years": employment_length,
+            "loan_amount": loan_amount.round(2),
+            "loan_term_months": loan_term,
+            "interest_rate": interest_rate.round(4),
+            "debt_to_income_ratio": debt_to_income.round(3),
+            "credit_score": credit_score.round().astype(int),
+            "credit_history_years": credit_history,
+            "previous_missed_payments": missed_payments,
+            "employment_status": employment_status,
+            "education_level": education_level,
+            "loan_purpose": loan_purpose,
+            "property_area": property_area,
+            "default": default,
+        }
+    )
+
+
+def load_or_build_dataset(csv_path: str | None = None) -> pd.DataFrame:
+    if csv_path:
+        return pd.read_csv(csv_path)
+    return build_dataset()
+
+
+def make_preprocessor() -> ColumnTransformer:
+    numeric_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+        ]
+    )
+    categorical_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="most_frequent")),
+            ("encoder", OneHotEncoder(handle_unknown="ignore")),
+        ]
+    )
+
+    return ColumnTransformer(
+        transformers=[
+            ("numeric", numeric_pipeline, NUMERIC_FEATURES),
+            ("categorical", categorical_pipeline, CATEGORICAL_FEATURES),
+        ]
+    )
+
+
+def make_models() -> dict[str, Pipeline]:
+    return {
+        "Logistic Regression": Pipeline(
+            steps=[
+                ("preprocessor", make_preprocessor()),
+                ("classifier", LogisticRegression(max_iter=1000, class_weight="balanced")),
+            ]
+        ),
+        "Random Forest": Pipeline(
+            steps=[
+                ("preprocessor", make_preprocessor()),
+                (
+                    "classifier",
+                    RandomForestClassifier(
+                        n_estimators=220,
+                        max_depth=10,
+                        class_weight="balanced",
+                        random_state=42,
+                    ),
+                ),
+            ]
+        ),
+        "Gradient Boosting": Pipeline(
+            steps=[
+                ("preprocessor", make_preprocessor()),
+                ("classifier", GradientBoostingClassifier(random_state=42)),
+            ]
+        ),
+    }
+
+
+def train_models(data: pd.DataFrame) -> TrainingResult:
+    x = data[NUMERIC_FEATURES + CATEGORICAL_FEATURES]
+    y = data[TARGET_COLUMN]
+    x_train, x_test, y_train, y_test = train_test_split(
+        x,
+        y,
+        test_size=0.2,
+        random_state=42,
+        stratify=y,
+    )
+
+    rows: list[dict[str, Any]] = []
+    confusion_matrices: dict[str, np.ndarray] = {}
+    trained_models = make_models()
+
+    for name, model in trained_models.items():
+        model.fit(x_train, y_train)
+        predictions = model.predict(x_test)
+        probabilities = model.predict_proba(x_test)[:, 1]
+        confusion_matrices[name] = confusion_matrix(y_test, predictions)
+        rows.append(
+            {
+                "model": name,
+                "accuracy": accuracy_score(y_test, predictions),
+                "precision": precision_score(y_test, predictions, zero_division=0),
+                "recall": recall_score(y_test, predictions, zero_division=0),
+                "f1_score": f1_score(y_test, predictions, zero_division=0),
+                "roc_auc": roc_auc_score(y_test, probabilities),
+            }
+        )
+
+    metrics = pd.DataFrame(rows).sort_values("roc_auc", ascending=False).reset_index(drop=True)
+    best_model_name = str(metrics.loc[0, "model"])
+
+    return TrainingResult(
+        best_model_name=best_model_name,
+        model=trained_models[best_model_name],
+        metrics=metrics,
+        confusion_matrices=confusion_matrices,
+        x_train=x_train,
+        x_test=x_test,
+        y_train=y_train,
+        y_test=y_test,
+    )
+
+
+def predict_default(model: Pipeline, applicant: dict[str, Any]) -> tuple[float, str]:
+    frame = pd.DataFrame([applicant])
+    probability = float(model.predict_proba(frame)[0, 1])
+
+    if probability >= 0.65:
+        risk = "High"
+    elif probability >= 0.35:
+        risk = "Medium"
+    else:
+        risk = "Low"
+
+    return probability, risk
+
+
+def get_feature_names(model: Pipeline) -> list[str]:
+    preprocessor = model.named_steps["preprocessor"]
+    return list(preprocessor.get_feature_names_out())


### PR DESCRIPTION
## Summary

- Added an end-to-end Explainable Loan Default Risk Prediction project.
- Included a reusable scikit-learn training pipeline with synthetic dataset generation, preprocessing, model comparison, metrics, and inference helpers.
- Added a Streamlit dashboard for applicant risk scoring, model metrics, confusion matrix, and SHAP-based local/global explanations.
- Documented setup, dataset fields, workflow, evaluation metrics, SHAP usage, and risk tiers.

## Models and Metrics

The project trains and compares:

- Logistic Regression
- Random Forest
- Gradient Boosting

Reported metrics include accuracy, precision, recall, F1-score, ROC-AUC, and confusion matrix.

## Validation

- Ran a smoke test that generated data, trained all models, selected the best model, and produced a sample prediction.
- Ran Python syntax checks for the dashboard and pipeline files.

Closes #1854