### PR TITLE
docs: add missing directory navigation to contribution setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,11 +354,12 @@ To submit your contributions, follow these steps:
 
 1. **Fork the Repository**: Click the "Fork" button at the top right corner of the repository to create your own copy.
 
-2. **Clone Your Fork**: Clone your forked repository to your local machine using the following command:
+2. **Clone Your Fork**: Clone your forked repository to your local machine and navigate into the directory:
     ```bash
-    git clone [https://github.com/Niketkumardheeryan/ML-CaPsule](https://github.com/Niketkumardheeryan/ML-CaPsule)
-
+    git clone https://github.com/Niketkumardheeryan/ML-CaPsule
+    cd ML-CaPsule
     git checkout -b my-feature
+    ```
     4. **Make Changes**: Make your desired changes to the codebase.
 
 5. **Commit Changes**: Commit your changes with a descriptive commit message:


### PR DESCRIPTION
## Description

This PR resolves a workflow friction point in the "Submitting a Pull Request" section. The installation instructions failed to include a `cd` command, which would cause contributors to attempt git operations outside of the project directory. I updated the instructions to include the necessary directory navigation step, ensuring that the `git checkout` command works correctly for new contributors.

## Related Issue

Fixes #None (just a documentation fix)

## Type of Change

* [ ] Bug Fix
* [ ] New Feature
* [x] Documentation Update
* [ ] Code Refactoring
* [ ] Performance Improvement

## Checklist

* [x] My code follows the project guidelines.
* [x] I have tested my changes.
* [x] I have updated documentation where necessary.
* [x] My changes do not break existing functionality.

## Screenshots (if applicable)

None

## Additional Notes

None