### PR TITLE
fix: replace incorrect duckduckgo-search dependency with ddgs

### DIFF
--- a/Autonomous Research AI Agent/requirements.txt
+++ b/Autonomous Research AI Agent/requirements.txt
@@ -1,6 +1,6 @@
 langchain
 langchain-community
 langchain-groq
-duckduckgo-search
+ddgs
 streamlit
 python-dotenv


### PR DESCRIPTION
## Fixes #1962

### Changes made
- Replaced incorrect dependency `duckduckgo-search` with `ddgs` in requirements.txt
- Verified imports in src/agent.py and src/tools.py use `from ddgs import DDGS`

### Why this fix
The application imports `ddgs`, but requirements.txt installs `duckduckgo-search`, causing a ModuleNotFoundError during startup.

### Result
The Autonomous Research AI Agent can now start without dependency import errors.