### PR TITLE
fix: resolve case-sensitive filename collision affecting Windows clones

### DIFF
--- a/website ML-CaPsule/readme.md
+++ b/website ML-CaPsule/readme.md
@@ -1,2 +1,0 @@
-# ML-CaPsule-website
-building full stack website for ML-CaPsule


### PR DESCRIPTION
## Summary

This pull request resolves the Windows clone issue caused by duplicate README files that differ only by letter casing.

### Changes
- Removed the duplicate `website ML-CaPsule/readme.md`.
- Retained `website ML-CaPsule/README.md` as the canonical file.

### Why

The repository contained both:

- `website ML-CaPsule/README.md`
- `website ML-CaPsule/readme.md`

On case-insensitive file systems such as Windows, Git cannot check out both files, resulting in the following warning during cloning:

```text
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree
```

Keeping a single `README.md` removes the filename collision and ensures consistent cross-platform behavior.

Fixes #2012