### PR TITLE
fix: warn instead of fail notebook health checks

### DIFF
--- a/.github/scripts/notebook_health_check.py
+++ b/.github/scripts/notebook_health_check.py
@@ -4,92 +4,261 @@ Notebook Health Check Bot
 Automatically tests Jupyter notebooks for errors, missing imports, and deprecations.
 """
 
+import argparse
+import json
 import os
-import sys
+import re
 import subprocess
+import sys
 from pathlib import Path
 
-def find_notebooks(root_dir="."):
-    """Find notebooks in specific directories only (avoid scanning entire 1.8GB repo)."""
+
+def emit_warning(message):
+    """Emit a warning that is visible in local logs and GitHub Actions."""
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        print(f"::warning::{message}")
+    else:
+        print(f"WARNING: {message}")
+
+
+def parse_args(argv=None):
+    """Parse command line arguments for the health check."""
+    parser = argparse.ArgumentParser(description="Run notebook health checks.")
+    parser.add_argument("--root-dir", default=".", help="Repository root to scan.")
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=None,
+        help="Optional list of changed files to restrict the scan to.",
+    )
+    return parser.parse_args(argv)
+
+
+def normalize_changed_files(changed_files):
+    """Normalize newline- or whitespace-delimited changed file paths into a list."""
+    normalized = []
+    for entry in changed_files or []:
+        if not entry:
+            continue
+        for part in re.split(r"\s+", entry.strip()):
+            if part:
+                normalized.append(part)
+    return normalized
+
+
+def find_notebooks(root_dir=".", changed_files=None):
+    """Find notebooks in specific directories only, or limit the scan to changed notebook files."""
     notebooks = []
-    root_path = Path(root_dir)
-    
+    root_path = Path(root_dir).resolve()
+
+    changed_file_entries = normalize_changed_files(changed_files)
+    env_changed_files = os.getenv("CHANGED_FILES", "")
+    if env_changed_files:
+        changed_file_entries.extend(normalize_changed_files([env_changed_files]))
+
+    if changed_file_entries:
+        for entry in changed_file_entries:
+            candidate = Path(entry)
+            if not candidate.is_absolute():
+                candidate = (root_path / candidate).resolve()
+            if candidate.exists() and candidate.is_file() and candidate.suffix.lower() == ".ipynb":
+                if ".ipynb_checkpoints" not in str(candidate):
+                    notebooks.append(candidate)
+        if notebooks:
+            return sorted(dict.fromkeys(notebooks))
+        print("No changed notebook files matched the health check criteria.")
+        return []
+
     # Only scan these folders (common notebook locations)
     folders_to_scan = ["notebooks", "examples", "tutorials", "docs", "guides"]
-    
+
     for folder in folders_to_scan:
         folder_path = root_path / folder
         if folder_path.exists():
             for path in folder_path.rglob("*.ipynb"):
                 if ".ipynb_checkpoints" not in str(path):
                     notebooks.append(path)
-    
+
     # If no notebooks found in specific folders, scan current directory only (not subdirectories)
     if not notebooks:
         for path in root_path.glob("*.ipynb"):
             notebooks.append(path)
-    
+
     # Also check for notebooks in root level (if any)
     for path in root_path.glob("*.ipynb"):
         if path not in notebooks:
             notebooks.append(path)
-    
-    return notebooks
+
+    return sorted(dict.fromkeys(notebooks))
+
+
+def classify_notebook(payload, notebook_path):
+    """Classify a notebook before execution to avoid unnecessary runtime and flag manual-review cases."""
+    notebook_name = str(notebook_path).lower()
+    source_text = ""
+
+    for cell in payload.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        source = cell.get("source", [])
+        if isinstance(source, list):
+            source_text += "".join(source)
+        elif isinstance(source, str):
+            source_text += source
+
+    source_text = source_text.lower()
+
+    manual_patterns = [
+        r"requests\.(get|post|put|delete)",
+        r"selenium|playwright|webdriver",
+        r"opencv|cv2",
+        r"pytube|youtube|streamlit|gradio",
+        r"google\.colab|drive\.mount",
+        r"api[_ -]?key|token|password",
+        r"openai|anthropic|huggingface|transformers",
+        r"torch\.load|joblib\.load|pickle\.load",
+    ]
+    skip_patterns = [
+        r"manual inspection",
+        r"todo|tbd|fixme",
+        r"<[^>]+>",
+    ]
+
+    requires_manual_inspection = any(re.search(pattern, source_text) for pattern in manual_patterns)
+    should_run = not requires_manual_inspection
+
+    if not should_run:
+        reason = "Notebook matches manual inspection heuristics and will be flagged for review."
+    elif any(re.search(pattern, source_text) for pattern in skip_patterns):
+        reason = "Notebook contains review markers and will be skipped."
+        should_run = False
+        requires_manual_inspection = True
+    else:
+        reason = "Notebook looks runnable and will be executed."
+
+    if "copy_of_" in notebook_name or "test" in notebook_name:
+        reason = f"{reason} Name-based heuristic also suggests a support notebook."
+        should_run = should_run and "test" not in notebook_name
+        requires_manual_inspection = requires_manual_inspection or "test" in notebook_name
+
+    return {
+        "should_run": should_run,
+        "requires_manual_inspection": requires_manual_inspection,
+        "reason": reason,
+    }
+
+
+def load_notebook_payload(notebook_path):
+    """Load notebook JSON content for pre-screening."""
+    try:
+        with open(notebook_path, "r", encoding="utf-8") as handle:
+            return json.loads(handle.read())
+    except Exception as exc:
+        return None
+
 
 def test_notebook(notebook_path):
     """Test a single notebook using nbconvert."""
     result = {
         "path": str(notebook_path),
         "success": False,
-        "error": None
+        "error": None,
+        "returncode": None,
+        "skipped": False,
+        "reason": None,
     }
-    
+
+    payload = load_notebook_payload(notebook_path)
+    if payload is None:
+        result["error"] = "Unable to read notebook JSON"
+        return result
+
+    classification = classify_notebook(payload, notebook_path)
+    result["reason"] = classification["reason"]
+    if not classification["should_run"]:
+        result["skipped"] = True
+        result["success"] = True
+        result["error"] = None
+        if classification["requires_manual_inspection"]:
+            emit_warning(f"{notebook_path}: {classification['reason']}")
+        else:
+            print(f"Skipping {notebook_path}: {classification['reason']}")
+        return result
+
     try:
-        # Run the notebook using nbconvert
-        subprocess.run(
+        completed = subprocess.run(
             [
-                "jupyter", "nbconvert", "--to", "notebook",
-                "--execute", str(notebook_path),
-                "--output", "-", "--allow-errors"
+                "jupyter",
+                "nbconvert",
+                "--to",
+                "notebook",
+                "--execute",
+                str(notebook_path),
+                "--output",
+                "-",
+                "--allow-errors",
             ],
             capture_output=True,
             text=True,
-            timeout=300
+            timeout=300,
         )
-        result["success"] = True
+        result["returncode"] = completed.returncode
+        result["success"] = completed.returncode == 0
+        if completed.returncode != 0:
+            output = (completed.stderr or completed.stdout).strip()
+            result["error"] = output or f"Notebook execution failed with exit code {completed.returncode}"
     except subprocess.TimeoutExpired:
         result["error"] = "Timeout (5 minutes)"
     except Exception as e:
         result["error"] = str(e)
-    
+
     return result
 
-def main():
-    notebooks = find_notebooks()
-    print(f"Found {len(notebooks)} notebooks")
-    
+
+def run_health_check(root_dir=".", changed_files=None):
+    """Run the notebook health checks and report failed notebooks as warnings."""
+    notebooks = find_notebooks(root_dir, changed_files)
+    if changed_files or os.getenv("CHANGED_FILES"):
+        print(f"Checking {len(notebooks)} changed notebook(s).")
+    else:
+        print(f"Found {len(notebooks)} notebooks")
+
     if not notebooks:
         print("No notebooks found to test.")
-        sys.exit(0)
-    
+        return []
+
     results = []
     for nb in notebooks:
         print(f"Testing: {nb}")
         result = test_notebook(nb)
         results.append(result)
-    
-    # Create issue for failed notebooks
-    failed = [r for r in results if not r["success"]]
-    
+
+    failed = [r for r in results if not r["success"] and not r.get("skipped")]
+    skipped = [r for r in results if r.get("skipped")]
+
     if failed:
-        print(f"\n❌ {len(failed)} notebooks failed:")
+        print(f"\n⚠️ {len(failed)} notebooks reported warnings:")
         for f in failed:
+            message = f"Notebook execution issue: {f['path']}: {f['error']}"
+            emit_warning(message)
             print(f"  - {f['path']}: {f['error']}")
-        sys.exit(1)
+
+    if skipped:
+        print(f"\nℹ️ {len(skipped)} notebooks were flagged for manual inspection and skipped:")
+        for item in skipped:
+            print(f"  - {item['path']}: {item['reason']}")
     else:
         print(f"\n✅ All {len(results)} notebooks passed!")
-        sys.exit(0)
+
+    return results
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    run_health_check(args.root_dir, args.changed_files)
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())
     

--- a/.github/scripts/notebook_health_check.py
+++ b/.github/scripts/notebook_health_check.py
@@ -137,6 +137,7 @@ def load_notebook_payload(notebook_path):
         with open(notebook_path, "r", encoding="utf-8") as handle:
             return json.loads(handle.read())
     except Exception as exc:
+        print(f"Error reading {notebook_path}: {exc}")
         return None
 
 
@@ -198,6 +199,9 @@ def test_notebook(notebook_path):
     return result
 
 
+import os
+import uuid
+
 def run_health_check(root_dir=".", changed_files=None):
     """Run the notebook health checks and report failed notebooks as warnings."""
     notebooks = find_notebooks(root_dir, changed_files)
@@ -221,27 +225,54 @@ def run_health_check(root_dir=".", changed_files=None):
 
     if failed:
         print(f"\n⚠️ {len(failed)} notebooks reported warnings:")
-        for f in failed:
-            message = f"Notebook execution issue: {f['path']}: {f['error']}"
+        for fail in failed:
+            message = f"Notebook execution issue: {fail['path']}: {fail['error']}"
             emit_warning(message)
-            print(f"  - {f['path']}: {f['error']}")
+            print(f"  - {fail['path']}: {fail['error']}")
 
     if skipped:
         print(f"\nℹ️ {len(skipped)} notebooks were flagged for manual inspection and skipped:")
         for item in skipped:
             print(f"  - {item['path']}: {item['reason']}")
     else:
-        print(f"\n✅ All {len(results)} notebooks passed!")
+        if results:
+            print(f"\n✅ All {len(results)} notebooks passed!")
 
-    with open("result.md", "w", encoding="utf-8") as f:
-        f.write(f"# Notebook Health Check Results\n\n")
-        f.write(f"Total notebooks checked: {len(results)}\n\n")
-        f.write(f"## Failed Notebooks ({len(failed)})\n")
-        for f in failed:
-            f.write(f"- **{f['path']}**: {f['error']}\n")
-        f.write(f"\n## Skipped Notebooks ({len(skipped)})\n")
-        for s in skipped:
-            f.write(f"- **{s['path']}**: {s['reason']}\n")
+    # --- Build the Markdown Report in memory ---
+    report_lines = [
+        "### 📝 Notebook Health Check Results",
+        f"**Total notebooks checked:** {len(results)}\n"
+    ]
+    
+    report_lines.append(f"#### Failed Notebooks ({len(failed)})")
+    if failed:
+        for fail in failed:
+            report_lines.append(f"- **{fail['path']}**: {fail['error']}")
+    else:
+        report_lines.append("None! 🎉")
+        
+    report_lines.append(f"\n#### Skipped Notebooks ({len(skipped)})")
+    if skipped:
+        for skip in skipped:
+            report_lines.append(f"- **{skip['path']}**: {skip['reason']}")
+    else:
+        report_lines.append("None")
+
+    report_string = "\n".join(report_lines)
+
+    # --- Write to GITHUB_OUTPUT ---
+    github_output = os.environ.get('GITHUB_OUTPUT')
+    if github_output:
+        # We use 'outfile' instead of 'f' to avoid confusion
+        with open(github_output, 'a', encoding="utf-8") as outfile:
+            delimiter = str(uuid.uuid4())
+            outfile.write(f"report<<{delimiter}\n")
+            outfile.write(f"{report_string}\n")
+            outfile.write(f"{delimiter}\n")
+    else:
+        # Fallback for running locally
+        print("\n--- Markdown Report ---")
+        print(report_string)
 
     return results
 

--- a/.github/scripts/notebook_health_check.py
+++ b/.github/scripts/notebook_health_check.py
@@ -218,7 +218,7 @@ def run_health_check(root_dir=".", changed_files=None):
     skipped = []
     report_lines = ["### 📝 Notebook Health Check Results"]
     
-    if not notebooks:
+    if not notebooks: # if no notebooks are found just print a message and add to the report
         print("No notebooks found to test.")
         report_lines.append("\n**No notebooks were found or changed.** No tests were run. 🎉")
     else:

--- a/.github/scripts/notebook_health_check.py
+++ b/.github/scripts/notebook_health_check.py
@@ -47,7 +47,10 @@ def normalize_changed_files(changed_files):
 
 
 def find_notebooks(root_dir=".", changed_files=None):
-    """Find notebooks in specific directories only, or limit the scan to changed notebook files."""
+    if changed_files is None:
+        changed_files = []
+
+    """Find notebooks in changed files or in common locations within the repository."""
     notebooks = []
     root_path = Path(root_dir).resolve()
 
@@ -68,26 +71,6 @@ def find_notebooks(root_dir=".", changed_files=None):
             return sorted(dict.fromkeys(notebooks))
         print("No changed notebook files matched the health check criteria.")
         return []
-
-    # Only scan these folders (common notebook locations)
-    folders_to_scan = ["notebooks", "examples", "tutorials", "docs", "guides"]
-
-    for folder in folders_to_scan:
-        folder_path = root_path / folder
-        if folder_path.exists():
-            for path in folder_path.rglob("*.ipynb"):
-                if ".ipynb_checkpoints" not in str(path):
-                    notebooks.append(path)
-
-    # If no notebooks found in specific folders, scan current directory only (not subdirectories)
-    if not notebooks:
-        for path in root_path.glob("*.ipynb"):
-            notebooks.append(path)
-
-    # Also check for notebooks in root level (if any)
-    for path in root_path.glob("*.ipynb"):
-        if path not in notebooks:
-            notebooks.append(path)
 
     return sorted(dict.fromkeys(notebooks))
 
@@ -249,6 +232,16 @@ def run_health_check(root_dir=".", changed_files=None):
             print(f"  - {item['path']}: {item['reason']}")
     else:
         print(f"\n✅ All {len(results)} notebooks passed!")
+
+    with open("result.md", "w", encoding="utf-8") as f:
+        f.write(f"# Notebook Health Check Results\n\n")
+        f.write(f"Total notebooks checked: {len(results)}\n\n")
+        f.write(f"## Failed Notebooks ({len(failed)})\n")
+        for f in failed:
+            f.write(f"- **{f['path']}**: {f['error']}\n")
+        f.write(f"\n## Skipped Notebooks ({len(skipped)})\n")
+        for s in skipped:
+            f.write(f"- **{s['path']}**: {s['reason']}\n")
 
     return results
 

--- a/.github/scripts/notebook_health_check.py
+++ b/.github/scripts/notebook_health_check.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 
@@ -50,16 +51,19 @@ def find_notebooks(root_dir=".", changed_files=None):
     if changed_files is None:
         changed_files = []
 
-    """Find notebooks in changed files or in common locations within the repository."""
     notebooks = []
     root_path = Path(root_dir).resolve()
 
     changed_file_entries = normalize_changed_files(changed_files)
     env_changed_files = os.getenv("CHANGED_FILES", "")
-    if env_changed_files:
+    
+    # Check if the bash script passed the fallback message instead of real files
+    is_fallback = "No changed files detected" in env_changed_files
+    
+    if env_changed_files and not is_fallback:
         changed_file_entries.extend(normalize_changed_files([env_changed_files]))
 
-    if changed_file_entries:
+    if changed_file_entries and not is_fallback:
         for entry in changed_file_entries:
             candidate = Path(entry)
             if not candidate.is_absolute():
@@ -72,6 +76,12 @@ def find_notebooks(root_dir=".", changed_files=None):
         print("No changed notebook files matched the health check criteria.")
         return []
 
+    # If we get here, no specific changed files were found, so do a full scan
+    print("Performing full notebook scan...")
+    for candidate in root_path.rglob("*.ipynb"):
+        if ".ipynb_checkpoints" not in str(candidate):
+            notebooks.append(candidate)
+            
     return sorted(dict.fromkeys(notebooks))
 
 
@@ -199,71 +209,65 @@ def test_notebook(notebook_path):
     return result
 
 
-import os
-import uuid
-
 def run_health_check(root_dir=".", changed_files=None):
     """Run the notebook health checks and report failed notebooks as warnings."""
     notebooks = find_notebooks(root_dir, changed_files)
-    if changed_files or os.getenv("CHANGED_FILES"):
-        print(f"Checking {len(notebooks)} changed notebook(s).")
-    else:
-        print(f"Found {len(notebooks)} notebooks")
-
+    
+    results = []
+    failed = []
+    skipped = []
+    report_lines = ["### 📝 Notebook Health Check Results"]
+    
     if not notebooks:
         print("No notebooks found to test.")
-        return []
-
-    results = []
-    for nb in notebooks:
-        print(f"Testing: {nb}")
-        result = test_notebook(nb)
-        results.append(result)
-
-    failed = [r for r in results if not r["success"] and not r.get("skipped")]
-    skipped = [r for r in results if r.get("skipped")]
-
-    if failed:
-        print(f"\n⚠️ {len(failed)} notebooks reported warnings:")
-        for fail in failed:
-            message = f"Notebook execution issue: {fail['path']}: {fail['error']}"
-            emit_warning(message)
-            print(f"  - {fail['path']}: {fail['error']}")
-
-    if skipped:
-        print(f"\nℹ️ {len(skipped)} notebooks were flagged for manual inspection and skipped:")
-        for item in skipped:
-            print(f"  - {item['path']}: {item['reason']}")
+        report_lines.append("\n**No notebooks were found or changed.** No tests were run. 🎉")
     else:
-        if results:
-            print(f"\n✅ All {len(results)} notebooks passed!")
+        print(f"Found {len(notebooks)} notebooks to test.")
+        for nb in notebooks:
+            print(f"Testing: {nb}")
+            result = test_notebook(nb)
+            results.append(result)
 
-    # --- Build the Markdown Report in memory ---
-    report_lines = [
-        "### 📝 Notebook Health Check Results",
-        f"**Total notebooks checked:** {len(results)}\n"
-    ]
-    
-    report_lines.append(f"#### Failed Notebooks ({len(failed)})")
-    if failed:
-        for fail in failed:
-            report_lines.append(f"- **{fail['path']}**: {fail['error']}")
-    else:
-        report_lines.append("None! 🎉")
+        failed = [r for r in results if not r["success"] and not r.get("skipped")]
+        skipped = [r for r in results if r.get("skipped")]
+
+        if failed:
+            print(f"\n⚠️ {len(failed)} notebooks reported warnings:")
+            for fail in failed:
+                message = f"Notebook execution issue: {fail['path']}: {fail['error']}"
+                emit_warning(message)
+                print(f"  - {fail['path']}: {fail['error']}")
+
+        if skipped:
+            print(f"\nℹ️ {len(skipped)} notebooks were flagged for manual inspection and skipped:")
+            for item in skipped:
+                print(f"  - {item['path']}: {item['reason']}")
+        else:
+            if results and not failed:
+                print(f"\n✅ All {len(results)} notebooks passed!")
+
+        # Build the Markdown Report content
+        report_lines.append(f"\n**Total notebooks checked:** {len(results)}\n")
         
-    report_lines.append(f"\n#### Skipped Notebooks ({len(skipped)})")
-    if skipped:
-        for skip in skipped:
-            report_lines.append(f"- **{skip['path']}**: {skip['reason']}")
-    else:
-        report_lines.append("None")
+        report_lines.append(f"#### Failed Notebooks ({len(failed)})")
+        if failed:
+            for fail in failed:
+                report_lines.append(f"- **{fail['path']}**: {fail['error']}")
+        else:
+            report_lines.append("None! 🎉")
+            
+        report_lines.append(f"\n#### Skipped Notebooks ({len(skipped)})")
+        if skipped:
+            for skip in skipped:
+                report_lines.append(f"- **{skip['path']}**: {skip['reason']}")
+        else:
+            report_lines.append("None")
 
     report_string = "\n".join(report_lines)
 
     # --- Write to GITHUB_OUTPUT ---
     github_output = os.environ.get('GITHUB_OUTPUT')
     if github_output:
-        # We use 'outfile' instead of 'f' to avoid confusion
         with open(github_output, 'a', encoding="utf-8") as outfile:
             delimiter = str(uuid.uuid4())
             outfile.write(f"report<<{delimiter}\n")
@@ -285,4 +289,3 @@ def main(argv=None):
 
 if __name__ == "__main__":
     sys.exit(main())
-    

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, master]
   workflow_dispatch:
+  
+permissions:
+  pull-requests: write
+  contents: read
 
 jobs:
   test-notebooks:

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -13,6 +13,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -26,12 +28,21 @@ jobs:
       
       - name: Get changed files
         id: changed-files
+        shell: bash
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin ${{ github.base_ref }} --depth=1
-            git diff --name-only origin/${{ github.base_ref }}...HEAD > changed_files.txt
+            git fetch origin "${{ github.base_ref }}" --depth=1 || true
+            if git merge-base --is-ancestor "origin/${{ github.base_ref }}" HEAD 2>/dev/null; then
+              git diff --name-only "origin/${{ github.base_ref }}"...HEAD > changed_files.txt || true
+            else
+              git diff --name-only "origin/${{ github.base_ref }}" HEAD > changed_files.txt || true
+            fi
           else
             git diff --name-only HEAD^ HEAD > changed_files.txt || true
+          fi
+          if [ ! -s changed_files.txt ]; then
+            echo "No changed files detected; falling back to the full notebook scan." > changed_files.txt
           fi
           echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
           cat changed_files.txt >> "$GITHUB_OUTPUT"

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -64,11 +64,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          # Pull the output from the previous step
+          REPO: ${{ github.repository }}
           REPORT_BODY: ${{ steps.health_check.outputs.report }}
         run: |
           if [ -n "$REPORT_BODY" ]; then
-            gh pr comment $PR_NUMBER --body "$REPORT_BODY"
+            echo "Creating JSON payload safely with jq..."
+            # jq safely escapes newlines and special characters for the JSON payload
+            jq -n --arg body "$REPORT_BODY" '{body: $body}' > payload.json
+            
+            echo "Posting comment to PR #$PR_NUMBER..."
+            curl -s -S -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Content-Type: application/json" \
+              -d @payload.json \
+              "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments"
           else
             echo "No report body found in GITHUB_OUTPUT."
           fi

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -49,20 +49,22 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Run notebook health check
+        id: health_check
         continue-on-error: true
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: python .github/scripts/notebook_health_check.py
         
       - name: Add Comment to PR
-        # Only run this step if it's a Pull Request (doesn't apply to push/workflow_dispatch)
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Pull the output from the previous step
+          REPORT_BODY: ${{ steps.health_check.outputs.report }}
         run: |
-          if [ -f "result.md" ]; then
-            gh pr comment $PR_NUMBER --body-file result.md
+          if [ -n "$REPORT_BODY" ]; then
+            gh pr comment $PR_NUMBER --body "$REPORT_BODY"
           else
-            echo "No report file found to comment."
+            echo "No report body found in GITHUB_OUTPUT."
           fi

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -53,17 +53,4 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: python .github/scripts/notebook_health_check.py
-
-      - name: Add Comment to PR
-        # Only run this step if it's a Pull Request (doesn't apply to push/workflow_dispatch)
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if [ -f "health_check_report.md" ]; then
-            gh pr comment $PR_NUMBER --body-file health_check_report.md
-          else
-            echo "No report file found to comment."
-          fi
         

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -24,6 +24,22 @@ jobs:
           pip install jupyter nbconvert pandas numpy
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       
+      - name: Get changed files
+        id: changed-files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin ${{ github.base_ref }} --depth=1
+            git diff --name-only origin/${{ github.base_ref }}...HEAD > changed_files.txt
+          else
+            git diff --name-only HEAD^ HEAD > changed_files.txt || true
+          fi
+          echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
+          cat changed_files.txt >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Run notebook health check
+        continue-on-error: true
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: python .github/scripts/notebook_health_check.py
         

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get changed files
         id: changed-files
         shell: bash
-        run: |
+        run: | # fetches newly added or changed files
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin "${{ github.base_ref }}" --depth=1 || true

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -53,4 +53,17 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: python .github/scripts/notebook_health_check.py
+
+      - name: Add Comment to PR
+        # Only run this step if it's a Pull Request (doesn't apply to push/workflow_dispatch)
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -f "health_check_report.md" ]; then
+            gh pr comment $PR_NUMBER --body-file health_check_report.md
+          else
+            echo "No report file found to comment."
+          fi
         

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -59,26 +59,20 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: python .github/scripts/notebook_health_check.py
         
-      - name: Add Comment to PR
-        if: github.event_name == 'pull_request'
+      - name: Show Warning on PR
+        if: always() # Run even if the python script throws an error
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
           REPORT_BODY: ${{ steps.health_check.outputs.report }}
         run: |
           if [ -n "$REPORT_BODY" ]; then
-            echo "Creating JSON payload safely with jq..."
-            # jq safely escapes newlines and special characters for the JSON payload
-            jq -n --arg body "$REPORT_BODY" '{body: $body}' > payload.json
+            # Multiline strings in annotations must use %0A for newlines
+            ESCAPED_REPORT="${REPORT_BODY//$'\n'/%0A}"
             
-            echo "Posting comment to PR #$PR_NUMBER..."
-            curl -s -S -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Content-Type: application/json" \
-              -d @payload.json \
-              "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments"
+            # This creates a yellow warning box on the PR summary page
+            echo "::warning title=Notebook Health Check Summary::$ESCAPED_REPORT"
+            
+            # Also write it to the Job Summary page for better formatting
+            echo "$REPORT_BODY" >> $GITHUB_STEP_SUMMARY
           else
-            echo "No report body found in GITHUB_OUTPUT."
+            echo "::warning title=Notebook Health Check::No notebooks were found or checked."
           fi

--- a/.github/workflows/notebook-health.yml
+++ b/.github/workflows/notebook-health.yml
@@ -54,3 +54,15 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: python .github/scripts/notebook_health_check.py
         
+      - name: Add Comment to PR
+        # Only run this step if it's a Pull Request (doesn't apply to push/workflow_dispatch)
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -f "result.md" ]; then
+            gh pr comment $PR_NUMBER --body-file result.md
+          else
+            echo "No report file found to comment."
+          fi

--- a/tests/test_notebook_health_check.py
+++ b/tests/test_notebook_health_check.py
@@ -1,0 +1,56 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "notebook_health_check.py"
+SPEC = importlib.util.spec_from_file_location("notebook_health_check", SCRIPT_PATH)
+notebook_health_check = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(notebook_health_check)
+
+
+class NotebookHealthCheckTests(unittest.TestCase):
+    def test_marks_manual_inspection_notebooks(self):
+        payload = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": [
+                        "import requests\n",
+                        "response = requests.get('https://example.com')\n",
+                    ],
+                }
+            ]
+        }
+        notebook_path = Path("manual_review.ipynb")
+
+        result = notebook_health_check.classify_notebook(payload, notebook_path)
+
+        self.assertTrue(result["requires_manual_inspection"])
+        self.assertFalse(result["should_run"])
+        self.assertIn("manual inspection", result["reason"])
+
+    def test_allows_simple_notebooks_to_run(self):
+        payload = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": [
+                        "import pandas as pd\n",
+                        "data = pd.DataFrame({'a': [1, 2]})\n",
+                    ],
+                }
+            ]
+        }
+        notebook_path = Path("simple_notebook.ipynb")
+
+        result = notebook_health_check.classify_notebook(payload, notebook_path)
+
+        self.assertFalse(result["requires_manual_inspection"])
+        self.assertTrue(result["should_run"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Related Issue

- This PR addresses the notebook health check workflow so that notebook execution issues are reported as warnings instead of causing the check to fail outright.
- It also reduces unnecessary runtime by pre-screening notebooks and limiting the check to changed files.

Closes: #1977

### Key Changes

- Updated the notebook health check script to emit warnings for failing notebook executions instead of exiting with a non-zero status.
- Added regex-based pre-screening to flag notebooks that likely require manual inspection before execution, helping avoid unnecessary processing.
- Modified the workflow to run the health check only against changed files, making the check faster and more relevant for PRs.
- Added regression tests to cover the new notebook classification behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
