### PR TITLE
fix : issue-reminder workflow

### DIFF
--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -16,15 +16,15 @@ jobs:
     - name: Check out the repository
       uses: actions/checkout@v4
 
-    - name: Warn, label, and close stale issues
+    - name: Warn, unassign, and mark stale issues as Up for Grab
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 0;
-          const daysBeforeClose = 0; // How many days to wait AFTER the warning to close it
+          const daysBeforeWarning = 7;
+          const daysBeforeUpForGrab = 7; // How many days to wait AFTER the warning
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
-          const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);
+          const upForGrabDate = new Date(Date.now() - daysBeforeUpForGrab * 24 * 60 * 60 * 1000);
           
           const issues = await github.paginate(github.rest.issues.listForRepo, {
             owner: context.repo.owner,
@@ -39,22 +39,33 @@ jobs:
             const hasWarningLabel = issue.labels.some(l => l.name === 'stale-warning');
 
             // SCENARIO 1: The issue was already warned, and still has no activity
-            if (hasWarningLabel && lastUpdated < closeDate) {
-              console.log(`Closing issue #${issue.number}`);
+            if (hasWarningLabel && lastUpdated < upForGrabDate) {
+              console.log(`Marking issue #${issue.number} as Up for Grab and unassigning`);
               
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `This issue is being closed due to no activity.`,
+                body: `This issue has been inactive for a while. It is now being unassigned and marked as **🤩 Up for Grab** for anyone else who wants to contribute!`,
               });
 
-              // Apply noActivity label
+              // Unassign the previous assignees if there are any
+              const currentAssignees = issue.assignees.map(assignee => assignee.login);
+              if (currentAssignees.length > 0) {
+                await github.rest.issues.removeAssignees({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  assignees: currentAssignees
+                });
+              }
+
+              // Apply the exact labels
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: ['noActivity']
+                labels: ['🤩 Up for Grab', 'noActivity']
               });
               
               // Remove the temporary warning label to keep things clean
@@ -72,11 +83,15 @@ jobs:
             else if (!hasWarningLabel && lastUpdated < warningDate) {
               console.log(`Warning issue #${issue.number}`);
               
+              // Grab the assignees to tag them, formatting it like "@user1, @user2"
+              const taggedAssignees = issue.assignees.map(a => `@${a.login}`).join(', ');
+              const greeting = taggedAssignees ? `👋 Hey ${taggedAssignees},` : `👋`;
+              
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `👋 This issue hasn't been updated in over ${daysBeforeWarning} days. Please check in to see if it is still relevant! Else this issue will be closed under NoActivity soon.`,
+                body: `${greeting} this issue hasn't been updated in over ${daysBeforeWarning} days. Please provide an update to keep it assigned to you! Otherwise, it will be unassigned and opened up for other contributors soon.`,
               });
 
               // Apply the temporary warning label so the bot remembers for next time

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -67,13 +67,6 @@ jobs:
                 });
               } catch (e) { /* ignore if removing fails */ }
 
-              // Close the issue
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed'
-              });
             } 
             // SCENARIO 2: The issue hasn't been warned yet, and has been inactive for 7 days
             else if (!hasWarningLabel && lastUpdated < warningDate) {

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -36,7 +36,7 @@ jobs:
             if (issue.pull_request) continue; // Skip Pull Requests
 
             const lastUpdated = new Date(issue.updated_at);
-            const hasWarningLabel = issue.labels.some(l => l.name === 'stale-warning');
+            const hasWarningLabel = issue.labels.some(l => l.name === 'noActivity-warning');
 
             // SCENARIO 1: The issue was already warned, and still has no activity
             if (hasWarningLabel && lastUpdated < upForGrabDate) {
@@ -74,7 +74,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
-                  name: 'stale-warning'
+                  name: 'noActivity-warning'
                 });
               } catch (e) { /* ignore if removing fails */ }
 
@@ -99,7 +99,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: ['stale-warning']
+                labels: ['noActivity-warning']
               });
             }
           }

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -20,8 +20,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 0;
-          const daysBeforeUpForGrab = 0; // How many days to wait AFTER the warning
+          const daysBeforeWarning = 2;
+          const daysBeforeUpForGrab = 5; // How many days to wait AFTER the warning
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
           const upForGrabDate = new Date(Date.now() - daysBeforeUpForGrab * 24 * 60 * 60 * 1000);

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -2,8 +2,11 @@ name: Issue Reminder
 
 on:
   schedule:
-    # Runs every day at 8 AM
     - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
 
 jobs:
   remind-stale-issues:
@@ -11,35 +14,84 @@ jobs:
 
     steps:
     - name: Check out the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Find and remind stale issues
-      uses: actions/github-script@v6
+    - name: Warn, label, and close stale issues
+      uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeReminder = 7;
-          const staleDate = new Date(Date.now() - daysBeforeReminder * 24 * 60 * 60 * 1000);
+          const daysBeforeWarning = 7;
+          const daysBeforeClose = 7; // How many days to wait AFTER the warning to close it
+
+          const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
+          const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);
           
-          const { data: issues } = await github.rest.issues.listForRepo({
+          const issues = await github.paginate(github.rest.issues.listForRepo, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             state: 'open',
-            since: staleDate.toISOString(),
           });
 
-          const staleIssues = issues.filter(issue => new Date(issue.updated_at) < staleDate);
+          for (const issue of issues) {
+            if (issue.pull_request) continue; // Skip Pull Requests
 
-          for (const issue of staleIssues) {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              body: `👋 This issue hasn't been updated in over ${daysBeforeReminder} days. Please check in to see if it is still relevant!`,
-            });
-          }
+            const lastUpdated = new Date(issue.updated_at);
+            const hasWarningLabel = issue.labels.some(l => l.name === 'stale-warning');
 
-          if (staleIssues.length === 0) {
-            console.log('No stale issues found. All issues are up-to-date.');
-          } else {
-            console.log(`${staleIssues.length} stale issue(s) found and reminded.`);
+            // SCENARIO 1: The issue was already warned, and still has no activity
+            if (hasWarningLabel && lastUpdated < closeDate) {
+              console.log(`Closing issue #${issue.number}`);
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `This issue is being closed due to no activity.`,
+              });
+
+              // Apply noActivity label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['noActivity']
+              });
+              
+              // Remove the temporary warning label to keep things clean
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: 'stale-warning'
+                });
+              } catch (e) { /* ignore if removing fails */ }
+
+              // Close the issue
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed'
+              });
+            } 
+            // SCENARIO 2: The issue hasn't been warned yet, and has been inactive for 7 days
+            else if (!hasWarningLabel && lastUpdated < warningDate) {
+              console.log(`Warning issue #${issue.number}`);
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `👋 This issue hasn't been updated in over ${daysBeforeWarning} days. Please check in to see if it is still relevant! Else this issue will be closed under NoActivity soon.`,
+              });
+
+              // Apply the temporary warning label so the bot remembers for next time
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['stale-warning']
+              });
+            }
           }

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -33,7 +33,7 @@ jobs:
           });
 
           for (const issue of issues) {
-            if (issue.pull_request) continue; // Skip Pull Requests
+            if (issue.pull_request) continue; // Skip Pull Requests to continue iterating throught the enitre array of issues
 
             const lastUpdated = new Date(issue.updated_at);
             const hasWarningLabel = issue.labels.some(l => l.name === 'noActivity-warning');

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -20,8 +20,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 7;
-          const daysBeforeClose = 7; // How many days to wait AFTER the warning to close it
+          const daysBeforeWarning = 0;
+          const daysBeforeClose = 0; // How many days to wait AFTER the warning to close it
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
           const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -20,8 +20,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 0;
-          const daysBeforeClose = 0; // How many days to wait AFTER the warning to close it
+          const daysBeforeWarning = 7;
+          const daysBeforeClose = 7; // How many days to wait AFTER the warning to close it
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
           const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -20,8 +20,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 7;
-          const daysBeforeUpForGrab = 7; // How many days to wait AFTER the warning
+          const daysBeforeWarning = 0;
+          const daysBeforeUpForGrab = 0; // How many days to wait AFTER the warning
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
           const upForGrabDate = new Date(Date.now() - daysBeforeUpForGrab * 24 * 60 * 60 * 1000);


### PR DESCRIPTION
**What is the issue before?** : 
- The workflow files fetches the issues and pull requests after stale and then the script applies a filter to separate issues and the ones which are not updated from stale date so finally the the total stale issues found will be null

The code that is bugged :

```javascript
const { data: issues } = await github.rest.issues.listForRepo({
            owner: context.repo.owner,
            repo: context.repo.repo,
            state: 'open',
            since: staleDate.toISOString(),
          });

          const staleIssues = issues.filter(issue => new Date(issue.updated_at) < staleDate);
```

The use of since here will give us the issues that are that are last updated at or after staleDate and issues.filter will make the stateIssues array empty 

Fixes :

```javascript
const issues = await github.paginate(github.rest.issues.listForRepo, {
            owner: context.repo.owner,
            repo: context.repo.repo,
            state: 'open',
          });

          for (const issue of issues) {
            if (issue.pull_request) continue; // Skip Pull Requests
```

for working example please check https://github.com/coolenough/ML-CaPsule/issues/2

This will fix #2002 