### PR TITLE
fix : no activity warnings if pr is active

### DIFF
--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -3,7 +3,6 @@ name: Auto Comment on PR
 on:
   pull_request_target:
     types: [opened]
-  workflow_dispatch: 
 
 permissions:
   issues: write

--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -3,6 +3,7 @@ name: Auto Comment on PR
 on:
   pull_request_target:
     types: [opened]
+  workflow_dispatch: 
 
 permissions:
   issues: write

--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -17,8 +17,8 @@ jobs:
       run: |
         COMMENT=$(cat <<EOF
         {
-          "body": "Thank you for submitting your pull request! 🙌 We'll review it as soon as possible. If there are any specific instructions or feedback regarding your PR, we'll provide them here. Thanks again for your contribution! 😊"
-        }
+          "body": "Thank you for submitting your pull request 🙌! Please assign this pull request yourself by commenting `/assign`. We'll review it as soon as possible. If there are any specific instructions or feedback regarding your PR, we'll provide them here. Thanks again for your contribution! 😊"
+        } 
         EOF
         )
         RESPONSE=$(curl -s -o response.json -w "%{http_code}" \
@@ -34,3 +34,22 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Try assign the author to PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          // Get the username of the person who opened the Pull Request
+          const author = context.payload.pull_request.user.login;
+          
+          console.log(`Assigning PR #${context.issue.number} to ${author}`);
+          
+          // Assign the author to the PR
+          await github.rest.issues.addAssignees({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            assignees: [author]
+          });s
+          
+
+    

--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -49,7 +49,7 @@ jobs:
             repo: context.repo.repo,
             issue_number: context.issue.number,
             assignees: [author]
-          });s
+          });
           
 
     

--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -1,4 +1,4 @@
-name: Auto Comment on PR
+name: Auto Comment and Assign on PR raise
 
 on:
   pull_request_target:

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -21,8 +21,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 0;
-          const daysBeforeClose = 0; // Days AFTER warning before closing/unassigning
+          const daysBeforeWarning = 2;
+          const daysBeforeClose = 5; // Days AFTER warning before closing/unassigning
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
           const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -21,8 +21,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 0;
-          const daysBeforeClose = 0; // Days AFTER warning before closing/unassigning
+          const daysBeforeWarning = 2;
+          const daysBeforeClose = 5; // Days AFTER warning before closing/unassigning
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
           const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);
@@ -37,13 +37,19 @@ jobs:
           for (const item of items) {
             const isPR = !!item.pull_request;
             let lastUpdated = new Date(item.updated_at);
+            
+            // Track all inactivity labels
             let hasWarningLabel = item.labels.some(l => l.name === 'noActivity-warning');
+            let hasNoActivityLabel = item.labels.some(l => l.name === 'noActivity');
+            let hasUpForGrabLabel = item.labels.some(l => l.name === '🤩 Up for Grab');
+            
             let isActiveByHuman = false;
 
             // ==========================================
             // SHARED ACTIVITY CHECK: Did a human comment?
             // ==========================================
-            if (hasWarningLabel) {
+            // Check for human comments if ANY inactivity label is present
+            if (hasWarningLabel || hasNoActivityLabel || hasUpForGrabLabel) {
               try {
                 const allComments = await github.paginate(github.rest.issues.listComments, {
                   owner: context.repo.owner,
@@ -69,7 +75,6 @@ jobs:
             // PROCESS PULL REQUESTS
             // ==========================================
             if (isPR) {
-              // 1. Check if PR is pending review
               try {
                 const reviews = await github.rest.pulls.listReviews({
                   owner: context.repo.owner,
@@ -77,31 +82,35 @@ jobs:
                   pull_number: item.number,
                 });
                 
-                // If there are no reviews, skip the stale process entirely!
                 if (reviews.data.length === 0) {
                   console.log(`PR #${item.number} is pending review. Skipping.`);
                   continue; 
                 }
               } catch (e) { console.log(`Could not fetch reviews for PR #${item.number}`); }
 
-              // 2. Auto-Recovery
-              if (hasWarningLabel && isActiveByHuman) {
-                console.log(`PR #${item.number} is active again! Removing warning.`);
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning'
-                  });
-                  
+              // AUTO-RECOVERY for PRs
+              if ((hasWarningLabel || hasNoActivityLabel) && isActiveByHuman) {
+                console.log(`PR #${item.number} is active again! Removing inactivity labels.`);
+                let removedLabels = [];
+                
+                if (hasWarningLabel) {
+                  try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning' }); removedLabels.push('`noActivity-warning`'); } catch (e) {}
+                  hasWarningLabel = false;
+                }
+                if (hasNoActivityLabel) {
+                  try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity' }); removedLabels.push('`noActivity`'); } catch (e) {}
+                  hasNoActivityLabel = false;
+                }
+                
+                if (removedLabels.length > 0) {
                   await github.rest.issues.createComment({
                     owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
-                    body: `Activity detected! The \`noActivity-warning\` label has been removed.`,
+                    body: `Activity detected! The ${removedLabels.join(' and ')} label(s) have been removed.`,
                   });
-                  
-                  hasWarningLabel = false;
-                } catch (e) {}
+                }
               }
 
-              // 3. Stale Logic for PRs
+              // Stale Logic for PRs
               if (hasWarningLabel && lastUpdated < closeDate) {
                 console.log(`Closing inactive PR #${item.number}`);
                 await github.rest.issues.createComment({
@@ -116,7 +125,7 @@ jobs:
                 });
                 try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning' }); } catch (e) {}
                 
-              } else if (!hasWarningLabel && lastUpdated < warningDate) {
+              } else if (!hasWarningLabel && !hasNoActivityLabel && lastUpdated < warningDate) {
                 console.log(`Warning PR #${item.number}`);
                 const author = item.user ? `@${item.user.login}` : '';
                 await github.rest.issues.createComment({
@@ -136,7 +145,6 @@ jobs:
               let linkedPRPendingReview = false;
               const linkedOpenPRs = [];
 
-              // 1. GraphQL Check for linked Pull Requests & their Review Status
               const query = `
                 query($owner: String!, $repo: String!, $num: Int!) {
                   repository(owner: $owner, name: $repo) {
@@ -172,7 +180,6 @@ jobs:
                     const prNumber = node.source.number;
                     const prReviewCount = node.source.reviews ? node.source.reviews.totalCount : 0;
                     
-                    // If a linked PR has 0 reviews, the ISSUE is also protected!
                     if (prReviewCount === 0) {
                       linkedPRPendingReview = true;
                     }
@@ -190,30 +197,38 @@ jobs:
                 }
               } catch (e) { console.log(`Could not fetch PR data for issue #${item.number}`); }
 
-              // If a linked PR is pending review, skip the stale process for this issue
               if (linkedPRPendingReview) {
                 console.log(`Issue #${item.number} has a linked PR pending review. Skipping.`);
                 continue;
               }
 
-              // 2. Auto-Recovery
-              if (hasWarningLabel && isActiveByHuman) {
-                console.log(`Issue #${item.number} is active again! Removing warning.`);
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning'
-                  });
-                  
+              // AUTO-RECOVERY for Issues
+              if ((hasWarningLabel || hasNoActivityLabel || hasUpForGrabLabel) && isActiveByHuman) {
+                console.log(`Issue #${item.number} is active again! Removing inactivity labels.`);
+                let removedLabels = [];
+                
+                if (hasWarningLabel) {
+                  try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning' }); removedLabels.push('`noActivity-warning`'); } catch (e) {}
+                  hasWarningLabel = false; 
+                }
+                if (hasNoActivityLabel) {
+                  try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity' }); removedLabels.push('`noActivity`'); } catch (e) {}
+                  hasNoActivityLabel = false;
+                }
+                if (hasUpForGrabLabel) {
+                  try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: '🤩 Up for Grab' }); removedLabels.push('`🤩 Up for Grab`'); } catch (e) {}
+                  hasUpForGrabLabel = false;
+                }
+                
+                if (removedLabels.length > 0) {
                   await github.rest.issues.createComment({
                     owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
-                    body: `Activity detected! The \`noActivity-warning\` label has been removed.`,
+                    body: `Activity detected! The ${removedLabels.join(', ')} label(s) have been removed.`,
                   });
-                  
-                  hasWarningLabel = false; 
-                } catch (e) {}
+                }
               }
 
-              // 3. Stale Logic for Issues
+              // Stale Logic for Issues
               if (hasWarningLabel && lastUpdated < closeDate) {
                 console.log(`Marking issue #${item.number} as Up for Grab`);
                 await github.rest.issues.createComment({
@@ -234,7 +249,6 @@ jobs:
                 
                 try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning' }); } catch (e) {}
 
-                // Close any linked Pull Requests
                 for (const prNumber of linkedOpenPRs) {
                   console.log(`Closing linked PR #${prNumber} due to issue inactivity`);
                   await github.rest.issues.createComment({
@@ -246,7 +260,7 @@ jobs:
                   });
                 }
 
-              } else if (!hasWarningLabel && lastUpdated < warningDate) {
+              } else if (!hasWarningLabel && !hasNoActivityLabel && lastUpdated < warningDate) {
                 console.log(`Warning issue #${item.number}`);
                 const taggedAssignees = item.assignees.map(a => `@${a.login}`).join(', ');
                 const greeting = taggedAssignees ? `👋 Hey ${taggedAssignees},` : `👋`;

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -1,4 +1,4 @@
-name: Issue Reminder
+name: Issue & PR Reminder
 
 on:
   schedule:
@@ -7,99 +7,257 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write 
 
 jobs:
-  remind-stale-issues:
+  remind-stale-items:
     runs-on: ubuntu-latest
 
     steps:
     - name: Check out the repository
       uses: actions/checkout@v4
 
-    - name: Warn, unassign, and mark stale issues as Up for Grab
+    - name: Warn, manage, and close stale Issues and PRs
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 2;
-          const daysBeforeUpForGrab = 5; // How many days to wait AFTER the warning
+          const daysBeforeWarning = 0;
+          const daysBeforeClose = 0; // Days AFTER warning before closing/unassigning
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
-          const upForGrabDate = new Date(Date.now() - daysBeforeUpForGrab * 24 * 60 * 60 * 1000);
+          const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);
           
-          const issues = await github.paginate(github.rest.issues.listForRepo, {
+          // listForRepo fetches BOTH Issues and Pull Requests
+          const items = await github.paginate(github.rest.issues.listForRepo, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             state: 'open',
           });
 
-          for (const issue of issues) {
-            if (issue.pull_request) continue; // Skip Pull Requests to continue iterating throught the enitre array of issues
+          for (const item of items) {
+            const isPR = !!item.pull_request;
+            let lastUpdated = new Date(item.updated_at);
+            let hasWarningLabel = item.labels.some(l => l.name === 'noActivity-warning');
+            let isActiveByHuman = false;
 
-            const lastUpdated = new Date(issue.updated_at);
-            const hasWarningLabel = issue.labels.some(l => l.name === 'noActivity-warning');
-
-            // SCENARIO 1: The issue was already warned, and still has no activity
-            if (hasWarningLabel && lastUpdated < upForGrabDate) {
-              console.log(`Marking issue #${issue.number} as Up for Grab and unassigning`);
-              
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: `This issue has been inactive for a while. It is now being unassigned and marked as **🤩 Up for Grab** for anyone else who wants to contribute!`,
-              });
-
-              // Unassign the previous assignees if there are any
-              const currentAssignees = issue.assignees.map(assignee => assignee.login);
-              if (currentAssignees.length > 0) {
-                await github.rest.issues.removeAssignees({
+            // ==========================================
+            // SHARED ACTIVITY CHECK: Did a human comment?
+            // ==========================================
+            if (hasWarningLabel) {
+              try {
+                const allComments = await github.paginate(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: issue.number,
-                  assignees: currentAssignees
+                  issue_number: item.number,
                 });
+                
+                if (allComments.length > 0) {
+                  const lastComment = allComments[allComments.length - 1];
+                  if (lastComment.user.login !== 'github-actions[bot]') {
+                    isActiveByHuman = true; // Human replied!
+                  }
+                }
+              } catch (e) { console.log(`Could not fetch comments for #${item.number}`); }
+            }
+
+            // Also consider it active if someone pushed code / updated the title recently
+            if (lastUpdated > warningDate) {
+              isActiveByHuman = true;
+            }
+
+            // ==========================================
+            // PROCESS PULL REQUESTS
+            // ==========================================
+            if (isPR) {
+              // 1. Check if PR is pending review
+              try {
+                const reviews = await github.rest.pulls.listReviews({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: item.number,
+                });
+                
+                // If there are no reviews, skip the stale process entirely!
+                if (reviews.data.length === 0) {
+                  console.log(`PR #${item.number} is pending review. Skipping.`);
+                  continue; 
+                }
+              } catch (e) { console.log(`Could not fetch reviews for PR #${item.number}`); }
+
+              // 2. Auto-Recovery
+              if (hasWarningLabel && isActiveByHuman) {
+                console.log(`PR #${item.number} is active again! Removing warning.`);
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning'
+                  });
+                  
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
+                    body: `Activity detected! The \`noActivity-warning\` label has been removed.`,
+                  });
+                  
+                  hasWarningLabel = false;
+                } catch (e) {}
               }
 
-              // Apply the exact labels
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                labels: ['🤩 Up for Grab', 'noActivity']
-              });
-              
-              // Remove the temporary warning label to keep things clean
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  name: 'noActivity-warning'
+              // 3. Stale Logic for PRs
+              if (hasWarningLabel && lastUpdated < closeDate) {
+                console.log(`Closing inactive PR #${item.number}`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
+                  body: `This Pull Request has been inactive for a while since its last review. It is now being closed due to no activity. If you want to continue working on it, feel free to leave a comment!`,
                 });
-              } catch (e) { /* ignore if removing fails */ }
-
+                await github.rest.pulls.update({
+                  owner: context.repo.owner, repo: context.repo.repo, pull_number: item.number, state: 'closed'
+                });
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, labels: ['noActivity']
+                });
+                try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning' }); } catch (e) {}
+                
+              } else if (!hasWarningLabel && lastUpdated < warningDate) {
+                console.log(`Warning PR #${item.number}`);
+                const author = item.user ? `@${item.user.login}` : '';
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
+                  body: `👋 Hey ${author}, this Pull Request hasn't been updated in over ${daysBeforeWarning} days since your last review. Please provide an update to keep it active! Otherwise, it will be closed soon.`,
+                });
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, labels: ['noActivity-warning']
+                });
+              }
             } 
-            // SCENARIO 2: The issue hasn't been warned yet, and has been inactive for 7 days
-            else if (!hasWarningLabel && lastUpdated < warningDate) {
-              console.log(`Warning issue #${issue.number}`);
-              
-              // Grab the assignees to tag them, formatting it like "@user1, @user2"
-              const taggedAssignees = issue.assignees.map(a => `@${a.login}`).join(', ');
-              const greeting = taggedAssignees ? `👋 Hey ${taggedAssignees},` : `👋`;
-              
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: `${greeting} this issue hasn't been updated in over ${daysBeforeWarning} days. Please provide an update to keep it assigned to you! Otherwise, it will be unassigned and opened up for other contributors soon.`,
-              });
+            
+            // ==========================================
+            // PROCESS ISSUES
+            // ==========================================
+            else {
+              let linkedPRPendingReview = false;
+              const linkedOpenPRs = [];
 
-              // Apply the temporary warning label so the bot remembers for next time
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                labels: ['noActivity-warning']
-              });
+              // 1. GraphQL Check for linked Pull Requests & their Review Status
+              const query = `
+                query($owner: String!, $repo: String!, $num: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $num) {
+                      timelineItems(itemTypes: [CROSS_REFERENCED_EVENT], last: 50) {
+                        nodes {
+                          ... on CrossReferencedEvent {
+                            source {
+                              ... on PullRequest {
+                                number
+                                state
+                                updatedAt
+                                reviews(first: 1) {
+                                  totalCount
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+              try {
+                const result = await github.graphql(query, {
+                  owner: context.repo.owner, repo: context.repo.repo, num: item.number
+                });
+                
+                const nodes = result.repository.issue.timelineItems.nodes;
+                for (const node of nodes) {
+                  if (node.source && node.source.state === 'OPEN') {
+                    const prNumber = node.source.number;
+                    const prReviewCount = node.source.reviews ? node.source.reviews.totalCount : 0;
+                    
+                    // If a linked PR has 0 reviews, the ISSUE is also protected!
+                    if (prReviewCount === 0) {
+                      linkedPRPendingReview = true;
+                    }
+
+                    if (!linkedOpenPRs.includes(prNumber)) {
+                      linkedOpenPRs.push(prNumber);
+                    }
+
+                    const prDate = new Date(node.source.updatedAt);
+                    if (prDate > lastUpdated) {
+                      lastUpdated = prDate; 
+                      isActiveByHuman = true; 
+                    }
+                  }
+                }
+              } catch (e) { console.log(`Could not fetch PR data for issue #${item.number}`); }
+
+              // If a linked PR is pending review, skip the stale process for this issue
+              if (linkedPRPendingReview) {
+                console.log(`Issue #${item.number} has a linked PR pending review. Skipping.`);
+                continue;
+              }
+
+              // 2. Auto-Recovery
+              if (hasWarningLabel && isActiveByHuman) {
+                console.log(`Issue #${item.number} is active again! Removing warning.`);
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning'
+                  });
+                  
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
+                    body: `Activity detected! The \`noActivity-warning\` label has been removed.`,
+                  });
+                  
+                  hasWarningLabel = false; 
+                } catch (e) {}
+              }
+
+              // 3. Stale Logic for Issues
+              if (hasWarningLabel && lastUpdated < closeDate) {
+                console.log(`Marking issue #${item.number} as Up for Grab`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
+                  body: `This issue has been inactive for a while. It is now being unassigned and marked as **🤩 Up for Grab** for anyone else who wants to contribute!`,
+                });
+
+                const currentAssignees = item.assignees.map(a => a.login);
+                if (currentAssignees.length > 0) {
+                  await github.rest.issues.removeAssignees({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, assignees: currentAssignees
+                  });
+                }
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, labels: ['🤩 Up for Grab', 'noActivity']
+                });
+                
+                try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, name: 'noActivity-warning' }); } catch (e) {}
+
+                // Close any linked Pull Requests
+                for (const prNumber of linkedOpenPRs) {
+                  console.log(`Closing linked PR #${prNumber} due to issue inactivity`);
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+                    body: `This Pull Request is being closed due to no activity on the linked issue. If you would like to continue working on this, please comment on the main issue!`
+                  });
+                  await github.rest.pulls.update({
+                    owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber, state: 'closed'
+                  });
+                }
+
+              } else if (!hasWarningLabel && lastUpdated < warningDate) {
+                console.log(`Warning issue #${item.number}`);
+                const taggedAssignees = item.assignees.map(a => `@${a.login}`).join(', ');
+                const greeting = taggedAssignees ? `👋 Hey ${taggedAssignees},` : `👋`;
+                
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number,
+                  body: `${greeting} this issue hasn't been updated in over ${daysBeforeWarning} days. Please provide an update or push to your linked PR to keep it assigned to you! Otherwise, it will be unassigned and opened up for other contributors soon.`,
+                });
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, labels: ['noActivity-warning']
+                });
+              }
             }
           }

--- a/.github/workflows/issue-reminder.yml
+++ b/.github/workflows/issue-reminder.yml
@@ -21,8 +21,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const daysBeforeWarning = 2;
-          const daysBeforeClose = 5; // Days AFTER warning before closing/unassigning
+          const daysBeforeWarning = 0;
+          const daysBeforeClose = 0; // Days AFTER warning before closing/unassigning
 
           const warningDate = new Date(Date.now() - daysBeforeWarning * 24 * 60 * 60 * 1000);
           const closeDate = new Date(Date.now() - daysBeforeClose * 24 * 60 * 60 * 1000);


### PR DESCRIPTION

This closes #2001 
This PR handles the checks the activity PR's linked to issues and if the provider is active it removes the warning label