### PR TITLE
Fixed : 2070

### DIFF
--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -75,7 +75,13 @@ jobs:
             });
           } else {
             // This creates the yellow warning annotation in the GitHub UI
-            core.warning('No linked issue found in the PR title or body.');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: linkedIssueNumber,
+              body: `No issue found to linked to this please link an issue`
+            });
+            core.setFailed('No linked issue found in the PR title or body.');
           }   
           
 

--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -74,7 +74,7 @@ jobs:
               body: `This pull request (#${issueNumber}) is linked to this issue.`
             });
           } else {
-            // This creates the yellow warning annotation in the GitHub UI
+            // This marks the workflow as failed 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/autocomment-pr-raise.yml
+++ b/.github/workflows/autocomment-pr-raise.yml
@@ -1,4 +1,4 @@
-name: Auto Comment and Assign on PR raise
+name: Auto Comment,Assign and Link Issue on PR raise
 
 on:
   pull_request_target:
@@ -50,6 +50,33 @@ jobs:
             issue_number: context.issue.number,
             assignees: [author]
           });
+
+    - name: link issue to pull request
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const issueNumber = context.payload.pull_request.number;
+          const issueTitle = context.payload.pull_request.title;
+          const issueBody = context.payload.pull_request.body || '';
+          
+          // Extract issue number from the PR title or body
+          const issueMatch = issueTitle.match(/#(\d+)/) || issueBody.match(/#(\d+)/);
+          
+          if (issueMatch) {
+            const linkedIssueNumber = parseInt(issueMatch[1], 10);
+            console.log(`Linking PR #${issueNumber} to Issue #${linkedIssueNumber}`);
+            
+            // Add a comment to the linked issue
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: linkedIssueNumber,
+              body: `This pull request (#${issueNumber}) is linked to this issue.`
+            });
+          } else {
+            // This creates the yellow warning annotation in the GitHub UI
+            core.warning('No linked issue found in the PR title or body.');
+          }   
           
 
     


### PR DESCRIPTION
This PR adds another job to workflow file `.github/workflows/autocomment-pr-raise.yml` that will now use regex search to find the issue in PR Title or Body and will link the issue and will raise a warning if it could not find any issue linked.

<details><summary>What's added</summary>

```yaml
 - name: link issue to pull request
      uses: actions/github-script@v7
      with:
        script: |
          const issueNumber = context.payload.pull_request.number;
          const issueTitle = context.payload.pull_request.title;
          const issueBody = context.payload.pull_request.body || '';
          
          // Extract issue number from the PR title or body
          const issueMatch = issueTitle.match(/#(\d+)/) || issueBody.match(/#(\d+)/);
          
          if (issueMatch) {
            const linkedIssueNumber = parseInt(issueMatch[1], 10);
            console.log(`Linking PR #${issueNumber} to Issue #${linkedIssueNumber}`);
            
            // Add a comment to the linked issue
            await github.rest.issues.createComment({
              owner: context.repo.owner,
              repo: context.repo.repo,
              issue_number: linkedIssueNumber,
              body: `This pull request (#${issueNumber}) is linked to this issue.`
            });
          } else {
            // This creates the yellow warning annotation in the GitHub UI
            core.warning('No linked issue found in the PR title or body.');
          } 
```

</details> 