### PR TITLE
ci : Fix SL Scan

### DIFF
--- a/.github/scripts/rename_for_scan.py
+++ b/.github/scripts/rename_for_scan.py
@@ -1,0 +1,31 @@
+import os
+
+def rename_with_underscores(directory="."):
+    """
+    Recursively finds all files in the given directory and 
+    replaces spaces in their filenames with underscores.
+    """
+    rename_count = 0
+    
+    # os.walk goes through all subdirectories and files
+    for root, dirs, files in os.walk(directory):
+        for filename in files:
+            if " " in filename:
+                # Generate the new name with underscores
+                new_name = filename.replace(" ", "_")
+                
+                # Get the absolute paths for renaming
+                old_file_path = os.path.join(root, filename)
+                new_file_path = os.path.join(root, new_name)
+                
+                # Perform the rename
+                os.rename(old_file_path, new_file_path)
+                print(f"Renamed: '{filename}'  ->  '{new_name}'")
+                rename_count += 1
+                
+    print(f"\nTotal files renamed: {rename_count}")
+
+if __name__ == "__main__":
+    # You can change "." to a specific folder path if needed, e.g., "./dataset"
+    print("Scanning directory for files with spaces...")
+    rename_with_underscores(".")

--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -70,8 +70,8 @@ jobs:
     - name: Fix SARIF URIs (Make paths relative)
     # this will fix the unwanted docker file paths 
       run: |
-        sed -i 's|file:///github/workspace/||g' reports/*.sarif
-        sed -i 's|/github/workspace/||g' reports/*.sarif
+        sudo sed -i 's|file:///github/workspace/||g' reports/*.sarif
+        sudo sed -i 's|/github/workspace/||g' reports/*.sarif
 
     - name: Upload report
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -31,21 +31,45 @@ jobs:
     #    Example: mvn compile, or npm install or pip install goes here
     # 3. Invoke Scan with the github token. Leave the workspace empty to use relative url
 
+    - name : Rename for Scan
+      run : python .github/scripts/rename_for_scan.py
+
+    #This jobs reduces the runtime
+    - name : Convert notebooks to scripts and clean unwanted data
+    # This removes unwanted data other than ipynbs and py files 
+    # ipynbs are converted to py files for code review to avoid the Scanner confusing with ipynbs big json structure
+    # These job also reduces the false posititves
+      run : |
+
+        pip install nbconvert
+
+        find . -name "*.ipynb" -exec jupyter nbconvert --to script {} \; || true
+
+        rm -rf .git .venv venv env node_modules
+
+        find . -type f ! -name "*.py" -delete
+
+        echo "Files remaining for the scanner:"
+        find . -type f
+
+
+
     - name: Perform Scan
       uses: ShiftLeftSecurity/scan-action@master
       env:
         WORKSPACE: ""
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SCAN_AUTO_BUILD: true
+        SCAN_AUTO_BUILD: false #this will make sure that the scanner will not build the entire directory again
+        #this is being done because the build is automatically check via build.yml
       with:
         output: reports
         # Scan auto-detects the languages in your project. To override uncomment the below variable and set the type
-        # type: credscan,java
+        type: credscan,python
         # type: python
 
     - name: Fix SARIF URIs (Make paths relative)
+    # this will fix the unwanted docker file paths 
       run: |
-        # This replaces the absolute container paths with relative paths
         sed -i 's|file:///github/workspace/||g' reports/*.sarif
         sed -i 's|/github/workspace/||g' reports/*.sarif
 


### PR DESCRIPTION
Fixes #2098

Noticing the SL-Workflow fails I have seen that the scanner is being run on the entire repository and repository has a lot of files with spaces in their filenames

- How did I fix it
> The checkout action downloads the repository to the runners local so instead of renaming the files in repository I am renaming them in runners local using `.github/scripts/rename_for_scan.py`

- However the this still scans on entire repository like csv,images,docker files,kubernetes configurations etc;
> I have tried to remove the files but the ipynb are just contain a lot of stored variables like visulization images etc;
> So I have to make sure that to convert the files to python files using nbconvert and then the job deletes every file other than .py
> This will reduce the runtime and also reduces lot of false positives

Hope this PR finds well
