### PR TITLE
feat: add interactive Gradio interface for Brain Tumor Detection

### DIFF
--- a/Brain Tumor Detection/README.md
+++ b/Brain Tumor Detection/README.md
@@ -110,3 +110,16 @@ Interpret Results: Analyze the model's performance using the visualizations and 
 
 Feel free to reach out if you encounter any issues or need further assistance with running the notebook.
 
+
++ ## Interactive UI with Gradio 🚀
++ We have added a lightweight, interactive web UI built using Gradio. You can easily upload MRI scans and see classification results in real-time.
++ 
++ ### How to run:
++ 1. Install dependencies:
++    ```bash
++    pip install -r requirements.txt
++    ```
++ 2. Run the application:
++    ```bash
++    python gradio_app.py
++    ```

--- a/Brain Tumor Detection/gradio_app.py
+++ b/Brain Tumor Detection/gradio_app.py
@@ -47,3 +47,5 @@ demo = gr.Interface(
 
 if __name__ == "__main__":
     demo.launch()
+
+    

--- a/Brain Tumor Detection/gradio_app.py
+++ b/Brain Tumor Detection/gradio_app.py
@@ -1,0 +1,49 @@
+import os
+import numpy as np
+import tensorflow as tf
+import gradio as gr
+from PIL import Image
+
+# Automatically find best_model.h5 in any of the possible directories
+dir_path = os.path.dirname(os.path.realpath(__file__))
+model_locations = [
+    os.path.join(dir_path, "best_model.h5"),
+    os.path.join(dir_path, "Web App", "best_model.h5"),
+    os.path.join(dir_path, "Model", "best_model.h5")
+]
+
+model = None
+for path in model_locations:
+    if os.path.exists(path):
+        model = tf.keras.models.load_model(path)
+        break
+
+if model is None:
+    raise FileNotFoundError("Could not find 'best_model.h5' in any project directories.")
+
+class_labels = ['Glioma', 'Meningioma', 'No tumor', 'Pituitary']
+
+def predict_tumor(img):
+    if img is None:
+        return "No image uploaded."
+    
+    # Preprocess image to match training input shape
+    img = img.resize((224, 224))
+    img_array = tf.keras.preprocessing.image.img_to_array(img)
+    img_array = np.expand_dims(img_array, axis=0)
+    
+    # Predict
+    predictions = model.predict(img_array)[0]
+    return {class_labels[i]: float(predictions[i]) for i in range(len(class_labels))}
+
+# Setup Interface
+demo = gr.Interface(
+    fn=predict_tumor,
+    inputs=gr.Image(type="pil", label="Upload Brain MRI Scan"),
+    outputs=gr.Label(num_top_classes=4, label="Prediction Confidence"),
+    title="Brain Tumor Classification Hub (Gradio)",
+    description="Upload an MRI scan to detect if a tumor is present and classify its type."
+)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/Brain Tumor Detection/requirements.txt
+++ b/Brain Tumor Detection/requirements.txt
@@ -5,3 +5,4 @@ matplotlib==3.6.3
 scikit-learn==1.2.1
 tensorflow==2.11.0
 keras==2.11.0
++gradio


### PR DESCRIPTION
### 🚀 Overview
This PR adds a lightweight, interactive **Gradio** web interface (`gradio_app.py`) for the `Brain Tumor Detection` model. Previously, users had to run a full Flask web application locally with HTML templates and styles, which is heavier to run and deploy. 

With this addition, users can easily run local inference by uploading MRI scans via drag-and-drop to classify tumors (Glioma, Meningioma, Pituitary, or No Tumor) with real-time confidence scores.

### 🛠️ Changes Made
1. **Added `Brain Tumor Detection/gradio_app.py`**:
   - Implemented a Gradio application that loads the pre-trained `best_model.h5` model.
   - Preprocesses input images to match the `224x224` shape used during training.
   - Computes and displays prediction confidences for all four classes.
2. **Updated `requirements.txt`**: Added `gradio` to the project's dependencies.
3. **Updated `README.md`**: Added a quick-start guide explaining how to install dependencies and run the Gradio application.

### 🧪 How to Test
1. Navigate to the project directory:
   ```bash
   cd "Brain Tumor Detection"