### PR TITLE
fix: resolve ValueError in Pandas tutorial notebook (ambiguous Series logic)-#1839

### DIFF
--- a/Basics of ML and DL/ML/Pandas/Pandas.ipynb
+++ b/Basics of ML and DL/ML/Pandas/Pandas.ipynb
@@ -3,7 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:36.847737Z",
+     "iopub.status.busy": "2026-07-25T05:19:36.847737Z",
+     "iopub.status.idle": "2026-07-25T05:19:36.854255Z",
+     "shell.execute_reply": "2026-07-25T05:19:36.853740Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# pandas provides fast, flexible and expressive data structures to make working with relational data both easy and intutive\n",
@@ -13,7 +20,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:36.858766Z",
+     "iopub.status.busy": "2026-07-25T05:19:36.857763Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.418547Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.418547Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import pandas as pd"
@@ -22,7 +36,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.421554Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.420554Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.429143Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.429143Z"
+    }
+   },
    "outputs": [],
    "source": [
     "iris = pd.read_csv(\"iris.data\")\n",
@@ -34,7 +55,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.431158Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.431158Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.445608Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.444088Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -64,7 +92,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.479551Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.479551Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.492047Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.491032Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -217,7 +252,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.494045Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.493045Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.504863Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.503850Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -372,7 +414,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.509413Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.509413Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.521637Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.519629Z"
+    }
+   },
    "outputs": [],
    "source": [
     "#loading the data with column names pre decided\n",
@@ -382,7 +431,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.525635Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.525635Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.537114Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.536099Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -478,7 +534,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.540104Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.539104Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.545707Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.544190Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -498,7 +561,14 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.547712Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.546714Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.552140Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.551134Z"
+    }
+   },
    "outputs": [],
    "source": [
     "#   df = iris   \n",
@@ -508,7 +578,14 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.554142Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.554142Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.559796Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.558657Z"
+    }
+   },
    "outputs": [],
    "source": [
     "df = iris.copy() \n",
@@ -520,7 +597,14 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.562794Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.561793Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.573121Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.572117Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -616,7 +700,14 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.575627Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.575627Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.583924Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.582919Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -694,7 +785,14 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.587187Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.585977Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.594578Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.594578Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -790,7 +888,14 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.596715Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.596715Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.603885Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.603885Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -868,7 +973,14 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.605892Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.605892Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.609767Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.609767Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -888,7 +1000,14 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.611947Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.611947Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.617072Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.616067Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -908,7 +1027,14 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.618073Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.618073Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.621609Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.621609Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# change column names\n",
@@ -919,7 +1045,14 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.623626Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.623626Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.627249Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.627249Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -939,7 +1072,14 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.629255Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.629255Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.634323Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.634323Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -964,7 +1104,14 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.636853Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.635841Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.647962Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.647962Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1078,7 +1225,14 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.650213Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.650213Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.653489Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.653489Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# note: in the above, \n",
@@ -1092,7 +1246,14 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.654494Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.654494Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.669083Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.669083Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1145,7 +1306,7 @@
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>Iris-virginica</td>\n",
+       "      <td>Iris-setosa</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>freq</th>\n",
@@ -1216,18 +1377,18 @@
        "</div>"
       ],
       "text/plain": [
-       "                sl          sw          pl          pw     flower_type\n",
-       "count   150.000000  150.000000  150.000000  150.000000             150\n",
-       "unique         NaN         NaN         NaN         NaN               3\n",
-       "top            NaN         NaN         NaN         NaN  Iris-virginica\n",
-       "freq           NaN         NaN         NaN         NaN              50\n",
-       "mean      5.843333    3.054000    3.758667    1.198667             NaN\n",
-       "std       0.828066    0.433594    1.764420    0.763161             NaN\n",
-       "min       4.300000    2.000000    1.000000    0.100000             NaN\n",
-       "25%       5.100000    2.800000    1.600000    0.300000             NaN\n",
-       "50%       5.800000    3.000000    4.350000    1.300000             NaN\n",
-       "75%       6.400000    3.300000    5.100000    1.800000             NaN\n",
-       "max       7.900000    4.400000    6.900000    2.500000             NaN"
+       "                sl          sw          pl          pw  flower_type\n",
+       "count   150.000000  150.000000  150.000000  150.000000          150\n",
+       "unique         NaN         NaN         NaN         NaN            3\n",
+       "top            NaN         NaN         NaN         NaN  Iris-setosa\n",
+       "freq           NaN         NaN         NaN         NaN           50\n",
+       "mean      5.843333    3.054000    3.758667    1.198667          NaN\n",
+       "std       0.828066    0.433594    1.764420    0.763161          NaN\n",
+       "min       4.300000    2.000000    1.000000    0.100000          NaN\n",
+       "25%       5.100000    2.800000    1.600000    0.300000          NaN\n",
+       "50%       5.800000    3.000000    4.350000    1.300000          NaN\n",
+       "75%       6.400000    3.300000    5.100000    1.800000          NaN\n",
+       "max       7.900000    4.400000    6.900000    2.500000          NaN"
       ]
      },
      "execution_count": 23,
@@ -1243,7 +1404,14 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.671088Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.671088Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.677265Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.676508Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1277,7 +1445,14 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.678446Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.678446Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.685995Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.685475Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1310,7 +1485,14 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.688008Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.687001Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.693951Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.693951Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1372,7 +1554,14 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.695964Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.695964Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.702428Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.702428Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1440,7 +1629,14 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.704439Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.704439Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.712803Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.712803Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1593,7 +1789,14 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.714815Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.714815Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.720575Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.720575Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1618,7 +1821,14 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.722587Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.722587Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.729153Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.729153Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1647,7 +1857,14 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.731418Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.731418Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.738307Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.738307Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1745,7 +1962,14 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.740316Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.740316Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.743365Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.743365Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# here 0,1,2,3  are lables that are different from positions"
@@ -1754,7 +1978,14 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.745639Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.744636Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.753507Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.753507Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1853,7 +2084,14 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.756023Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.754513Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.763412Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.763412Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1953,7 +2191,14 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.764417Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.764417Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.768982Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.768982Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# as we can see that 0th label got deleted so now starting of a from 1 label"
@@ -1962,7 +2207,14 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.771303Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.771303Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.773746Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.773746Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# what happens if we again run that command----->  ERROR bcos there is not any 0th label present in a\n",
@@ -1973,7 +2225,14 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.775760Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.775760Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.783779Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.783272Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2073,7 +2332,14 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.785791Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.785791Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.793946Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.793946Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2170,7 +2436,14 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.795711Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.795711Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.805752Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.805229Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2314,15 +2587,22 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.807758Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.807758Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.811267Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.811267Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Int64Index([  1,   2,   6,   7,   9,  10,  11,  12,  13,  14,\n",
-       "            ...\n",
-       "            140, 141, 142, 143, 144, 145, 146, 147, 148, 149],\n",
-       "           dtype='int64', length=145)"
+       "Index([  1,   2,   6,   7,   9,  10,  11,  12,  13,  14,\n",
+       "       ...\n",
+       "       140, 141, 142, 143, 144, 145, 146, 147, 148, 149],\n",
+       "      dtype='int64', length=145)"
       ]
      },
      "execution_count": 40,
@@ -2338,7 +2618,14 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.813278Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.813278Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.817341Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.816334Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# as we can see that there is  no label of 0 and 3"
@@ -2347,7 +2634,14 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.819344Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.819344Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.823438Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.823438Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2367,7 +2661,14 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.824950Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.824950Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.832975Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.832975Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2463,7 +2764,14 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.835850Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.835850Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.843092Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.843092Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2563,12 +2871,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.845924Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.844099Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.851117Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.850611Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Int64Index([2, 6], dtype='int64')"
+       "Index([2, 6], dtype='int64')"
       ]
      },
      "execution_count": 45,
@@ -2583,7 +2898,14 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.853123Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.853123Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.860828Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.860828Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2682,7 +3004,14 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.862834Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.862834Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.867089Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.865837Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# note: labels are stick to rows"
@@ -2691,7 +3020,14 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.869115Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.868090Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.874303Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.874303Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2722,7 +3058,14 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.876831Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.875824Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.886861Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.886861Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2875,32 +3218,408 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {},
+   "execution_count": 50,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.889044Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.889044Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.903448Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.903448Z"
+    }
+   },
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-51-a21bce394e3e>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;31m#selecting data based on some condition applied on feature values in columns\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[1;31m#say, we want to select only those rows, where sl > 6 and pl > 5\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 3\u001b[1;33m \u001b[0miris\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0miris\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msl\u001b[0m \u001b[1;33m>\u001b[0m \u001b[1;36m6\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mand\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0miris\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpl\u001b[0m \u001b[1;33m>\u001b[0m \u001b[1;36m5\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\pandas\\core\\generic.py\u001b[0m in \u001b[0;36m__nonzero__\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m   1327\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1328\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m__nonzero__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1329\u001b[1;33m         raise ValueError(\n\u001b[0m\u001b[0;32m   1330\u001b[0m             \u001b[1;34mf\"The truth value of a {type(self).__name__} is ambiguous. \"\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1331\u001b[0m             \u001b[1;34m\"Use a.empty, a.bool(), a.item(), a.any() or a.all().\"\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mValueError\u001b[0m: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()."
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sl</th>\n",
+       "      <th>sw</th>\n",
+       "      <th>pl</th>\n",
+       "      <th>pw</th>\n",
+       "      <th>species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>100</th>\n",
+       "      <td>6.3</td>\n",
+       "      <td>3.3</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>102</th>\n",
+       "      <td>7.1</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.9</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>103</th>\n",
+       "      <td>6.3</td>\n",
+       "      <td>2.9</td>\n",
+       "      <td>5.6</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>104</th>\n",
+       "      <td>6.5</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.8</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>105</th>\n",
+       "      <td>7.6</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>6.6</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>107</th>\n",
+       "      <td>7.3</td>\n",
+       "      <td>2.9</td>\n",
+       "      <td>6.3</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>108</th>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>5.8</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>7.2</td>\n",
+       "      <td>3.6</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>110</th>\n",
+       "      <td>6.5</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>111</th>\n",
+       "      <td>6.4</td>\n",
+       "      <td>2.7</td>\n",
+       "      <td>5.3</td>\n",
+       "      <td>1.9</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>112</th>\n",
+       "      <td>6.8</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>115</th>\n",
+       "      <td>6.4</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>5.3</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>116</th>\n",
+       "      <td>6.5</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>117</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>3.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>118</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.6</td>\n",
+       "      <td>6.9</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>120</th>\n",
+       "      <td>6.9</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>5.7</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>122</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>124</th>\n",
+       "      <td>6.7</td>\n",
+       "      <td>3.3</td>\n",
+       "      <td>5.7</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>125</th>\n",
+       "      <td>7.2</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>128</th>\n",
+       "      <td>6.4</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>5.6</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>129</th>\n",
+       "      <td>7.2</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.8</td>\n",
+       "      <td>1.6</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>130</th>\n",
+       "      <td>7.4</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>1.9</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>131</th>\n",
+       "      <td>7.9</td>\n",
+       "      <td>3.8</td>\n",
+       "      <td>6.4</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>132</th>\n",
+       "      <td>6.4</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>5.6</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>133</th>\n",
+       "      <td>6.3</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>134</th>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2.6</td>\n",
+       "      <td>5.6</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>135</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>136</th>\n",
+       "      <td>6.3</td>\n",
+       "      <td>3.4</td>\n",
+       "      <td>5.6</td>\n",
+       "      <td>2.4</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>137</th>\n",
+       "      <td>6.4</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>139</th>\n",
+       "      <td>6.9</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>5.4</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>140</th>\n",
+       "      <td>6.7</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>5.6</td>\n",
+       "      <td>2.4</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>141</th>\n",
+       "      <td>6.9</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>143</th>\n",
+       "      <td>6.8</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>5.9</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>144</th>\n",
+       "      <td>6.7</td>\n",
+       "      <td>3.3</td>\n",
+       "      <td>5.7</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>145</th>\n",
+       "      <td>6.7</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>147</th>\n",
+       "      <td>6.5</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>148</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>3.4</td>\n",
+       "      <td>5.4</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>Iris-virginica</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      sl   sw   pl   pw         species\n",
+       "100  6.3  3.3  6.0  2.5  Iris-virginica\n",
+       "102  7.1  3.0  5.9  2.1  Iris-virginica\n",
+       "103  6.3  2.9  5.6  1.8  Iris-virginica\n",
+       "104  6.5  3.0  5.8  2.2  Iris-virginica\n",
+       "105  7.6  3.0  6.6  2.1  Iris-virginica\n",
+       "107  7.3  2.9  6.3  1.8  Iris-virginica\n",
+       "108  6.7  2.5  5.8  1.8  Iris-virginica\n",
+       "109  7.2  3.6  6.1  2.5  Iris-virginica\n",
+       "110  6.5  3.2  5.1  2.0  Iris-virginica\n",
+       "111  6.4  2.7  5.3  1.9  Iris-virginica\n",
+       "112  6.8  3.0  5.5  2.1  Iris-virginica\n",
+       "115  6.4  3.2  5.3  2.3  Iris-virginica\n",
+       "116  6.5  3.0  5.5  1.8  Iris-virginica\n",
+       "117  7.7  3.8  6.7  2.2  Iris-virginica\n",
+       "118  7.7  2.6  6.9  2.3  Iris-virginica\n",
+       "120  6.9  3.2  5.7  2.3  Iris-virginica\n",
+       "122  7.7  2.8  6.7  2.0  Iris-virginica\n",
+       "124  6.7  3.3  5.7  2.1  Iris-virginica\n",
+       "125  7.2  3.2  6.0  1.8  Iris-virginica\n",
+       "128  6.4  2.8  5.6  2.1  Iris-virginica\n",
+       "129  7.2  3.0  5.8  1.6  Iris-virginica\n",
+       "130  7.4  2.8  6.1  1.9  Iris-virginica\n",
+       "131  7.9  3.8  6.4  2.0  Iris-virginica\n",
+       "132  6.4  2.8  5.6  2.2  Iris-virginica\n",
+       "133  6.3  2.8  5.1  1.5  Iris-virginica\n",
+       "134  6.1  2.6  5.6  1.4  Iris-virginica\n",
+       "135  7.7  3.0  6.1  2.3  Iris-virginica\n",
+       "136  6.3  3.4  5.6  2.4  Iris-virginica\n",
+       "137  6.4  3.1  5.5  1.8  Iris-virginica\n",
+       "139  6.9  3.1  5.4  2.1  Iris-virginica\n",
+       "140  6.7  3.1  5.6  2.4  Iris-virginica\n",
+       "141  6.9  3.1  5.1  2.3  Iris-virginica\n",
+       "143  6.8  3.2  5.9  2.3  Iris-virginica\n",
+       "144  6.7  3.3  5.7  2.5  Iris-virginica\n",
+       "145  6.7  3.0  5.2  2.3  Iris-virginica\n",
+       "147  6.5  3.0  5.2  2.0  Iris-virginica\n",
+       "148  6.2  3.4  5.4  2.3  Iris-virginica"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "#selecting data based on some condition applied on feature values in columns\n",
     "#say, we want to select only those rows, where sl > 6 and pl > 5\n",
-    "iris[(iris.sl > 6) and (iris.pl > 5)]"
+    "iris[(iris.sl > 6) & (iris.pl > 5)]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {},
+   "execution_count": 51,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.905958Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.905958Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.920816Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.919861Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3317,7 +4036,7 @@
        "49  5.0  3.3  1.4  0.2  Iris-setosa"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3328,8 +4047,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
+   "execution_count": 52,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.922373Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.922373Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.935725Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.935208Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3431,7 +4157,7 @@
        "max     5.800000   4.400000   1.900000   0.600000"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3442,8 +4168,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {},
+   "execution_count": 53,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.937759Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.937759Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.943103Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.943103Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3468,14 +4201,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {},
+   "execution_count": 54,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.945627Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.944114Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.949633Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.949633Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "sl                       5\n",
+      "sl                     5.0\n",
       "sw                     3.4\n",
       "pl                     1.5\n",
       "pw                     0.2\n",
@@ -3490,14 +4230,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
-   "metadata": {},
+   "execution_count": 55,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.952018Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.952018Z",
+     "iopub.status.idle": "2026-07-25T05:19:37.956528Z",
+     "shell.execute_reply": "2026-07-25T05:19:37.956016Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "sl                       5\n",
+      "sl                     5.0\n",
       "sw                     3.4\n",
       "pl                     1.5\n",
       "pw                     0.2\n",
@@ -3512,31 +4259,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
-   "metadata": {},
+   "execution_count": 56,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:37.957531Z",
+     "iopub.status.busy": "2026-07-25T05:19:37.957531Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.855622Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.855622Z"
+    }
+   },
    "outputs": [
     {
      "ename": "KeyError",
      "evalue": "0",
      "output_type": "error",
      "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\pandas\\core\\indexes\\base.py\u001b[0m in \u001b[0;36mget_loc\u001b[1;34m(self, key, method, tolerance)\u001b[0m\n\u001b[0;32m   2894\u001b[0m             \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 2895\u001b[1;33m                 \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mcasted_key\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   2896\u001b[0m             \u001b[1;32mexcept\u001b[0m \u001b[0mKeyError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0merr\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mpandas\\_libs\\index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[1;34m()\u001b[0m\n",
-      "\u001b[1;32mpandas\\_libs\\index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[1;34m()\u001b[0m\n",
-      "\u001b[1;32mpandas\\_libs\\hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.Int64HashTable.get_item\u001b[1;34m()\u001b[0m\n",
-      "\u001b[1;32mpandas\\_libs\\hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.Int64HashTable.get_item\u001b[1;34m()\u001b[0m\n",
-      "\u001b[1;31mKeyError\u001b[0m: 0",
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexes\\base.py:3812\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3811\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m3812\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43m_engine\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43mget_loc\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mcasted_key\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n\u001b[32m   3813\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:167\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m--> \u001b[39m\u001b[32m167\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:196\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m--> \u001b[39m\u001b[32m196\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:2606\u001b[39m, in \u001b[36mpandas._libs.hashtable.Int64HashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m2606\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:2630\u001b[39m, in \u001b[36mpandas._libs.hashtable.Int64HashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m2630\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
+      "\u001b[31mKeyError\u001b[39m: 0",
       "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-57-fd91572a67d7>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mloc\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;31m# error dega\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m__getitem__\u001b[1;34m(self, key)\u001b[0m\n\u001b[0;32m    877\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    878\u001b[0m             \u001b[0mmaybe_callable\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcom\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mapply_if_callable\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 879\u001b[1;33m             \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_getitem_axis\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmaybe_callable\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    880\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    881\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m_is_scalar_access\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mTuple\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m_getitem_axis\u001b[1;34m(self, key, axis)\u001b[0m\n\u001b[0;32m   1108\u001b[0m         \u001b[1;31m# fall thru to straight lookup\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1109\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_validate_key\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1110\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_get_label\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1111\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1112\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m_get_slice_axis\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mslice_obj\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mslice\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mint\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\pandas\\core\\indexing.py\u001b[0m in \u001b[0;36m_get_label\u001b[1;34m(self, label, axis)\u001b[0m\n\u001b[0;32m   1057\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m_get_label\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlabel\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mint\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1058\u001b[0m         \u001b[1;31m# GH#5667 this will fail if the label is not present in the axis.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1059\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mxs\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mlabel\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1060\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1061\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m_handle_lowerdim_multi_index_axis0\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtup\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mTuple\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\pandas\\core\\generic.py\u001b[0m in \u001b[0;36mxs\u001b[1;34m(self, key, axis, level, drop_level)\u001b[0m\n\u001b[0;32m   3489\u001b[0m             \u001b[0mloc\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mnew_index\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_loc_level\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mdrop_level\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mdrop_level\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3490\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 3491\u001b[1;33m             \u001b[0mloc\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   3492\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3493\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mloc\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mnp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mndarray\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\pandas\\core\\indexes\\base.py\u001b[0m in \u001b[0;36mget_loc\u001b[1;34m(self, key, method, tolerance)\u001b[0m\n\u001b[0;32m   2895\u001b[0m                 \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mcasted_key\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   2896\u001b[0m             \u001b[1;32mexcept\u001b[0m \u001b[0mKeyError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0merr\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 2897\u001b[1;33m                 \u001b[1;32mraise\u001b[0m \u001b[0mKeyError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0merr\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   2898\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   2899\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mtolerance\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mKeyError\u001b[0m: 0"
+      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[56]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m print(df.loc[\u001b[32m0\u001b[39m]) \u001b[38;5;66;03m# error dega\u001b[39;00m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexing.py:1192\u001b[39m, in \u001b[36m_LocationIndexer.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   1190\u001b[39m maybe_callable = com.apply_if_callable(key, \u001b[38;5;28mself\u001b[39m.obj)\n\u001b[32m   1191\u001b[39m maybe_callable = \u001b[38;5;28mself\u001b[39m._check_deprecated_callable_usage(key, maybe_callable)\n\u001b[32m-> \u001b[39m\u001b[32m1192\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43m_getitem_axis\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mmaybe_callable\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m=\u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexing.py:1432\u001b[39m, in \u001b[36m_LocIndexer._getitem_axis\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1430\u001b[39m \u001b[38;5;66;03m# fall thru to straight lookup\u001b[39;00m\n\u001b[32m   1431\u001b[39m \u001b[38;5;28mself\u001b[39m._validate_key(key, axis)\n\u001b[32m-> \u001b[39m\u001b[32m1432\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43m_get_label\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mkey\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m=\u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexing.py:1382\u001b[39m, in \u001b[36m_LocIndexer._get_label\u001b[39m\u001b[34m(self, label, axis)\u001b[39m\n\u001b[32m   1380\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_get_label\u001b[39m(\u001b[38;5;28mself\u001b[39m, label, axis: AxisInt):\n\u001b[32m   1381\u001b[39m     \u001b[38;5;66;03m# GH#5567 this will fail if the label is not present in the axis.\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1382\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43mobj\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43mxs\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mlabel\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m=\u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\generic.py:4323\u001b[39m, in \u001b[36mNDFrame.xs\u001b[39m\u001b[34m(self, key, axis, level, drop_level)\u001b[39m\n\u001b[32m   4319\u001b[39m                     new_index = index[loc : loc + \u001b[32m1\u001b[39m]\n\u001b[32m   4320\u001b[39m                 \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   4321\u001b[39m                     new_index = index[loc]\n\u001b[32m   4322\u001b[39m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m4323\u001b[39m             loc = index.get_loc(key)\n\u001b[32m   4324\u001b[39m \n\u001b[32m   4325\u001b[39m             \u001b[38;5;28;01mif\u001b[39;00m isinstance(loc, np.ndarray):\n\u001b[32m   4326\u001b[39m                 \u001b[38;5;28;01mif\u001b[39;00m loc.dtype == np.bool_:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexes\\base.py:3819\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3814\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(casted_key, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[32m   3815\u001b[39m         \u001b[38;5;28misinstance\u001b[39m(casted_key, abc.Iterable)\n\u001b[32m   3816\u001b[39m         \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28many\u001b[39m(\u001b[38;5;28misinstance\u001b[39m(x, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m casted_key)\n\u001b[32m   3817\u001b[39m     ):\n\u001b[32m   3818\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[32m-> \u001b[39m\u001b[32m3819\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m   3820\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[32m   3821\u001b[39m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[32m   3822\u001b[39m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[32m   3823\u001b[39m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n\u001b[32m   3824\u001b[39m     \u001b[38;5;28mself\u001b[39m._check_indexing_error(key)\n",
+      "\u001b[31mKeyError\u001b[39m: 0"
      ]
     }
    ],
@@ -3546,8 +4300,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
-   "metadata": {},
+   "execution_count": 57,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.858630Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.857633Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.874243Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.873234Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3631,7 +4392,7 @@
        "12  4.8  3.0  1.4  0.1  Iris-setosa"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3646,8 +4407,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
-   "metadata": {},
+   "execution_count": 58,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.876760Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.876760Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.885799Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.885799Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3731,7 +4499,7 @@
        "5    1.0  1.0  1.0  1.0     Iris-setosa"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3742,19 +4510,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
-   "metadata": {},
+   "execution_count": 59,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.887816Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.887816Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.892063Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.892063Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Int64Index([  7,   9,  10,  11,  12,  13,  14,  15,  16,  17,\n",
-       "            ...\n",
-       "            142, 143, 144, 145, 146, 147, 148, 149,   4,   5],\n",
-       "           dtype='int64', length=144)"
+       "Index([  7,   9,  10,  11,  12,  13,  14,  15,  16,  17,\n",
+       "       ...\n",
+       "       142, 143, 144, 145, 146, 147, 148, 149,   4,   5],\n",
+       "      dtype='int64', length=144)"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3765,8 +4540,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {},
+   "execution_count": 60,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.894068Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.894068Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.906925Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.906925Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -3919,7 +4701,7 @@
        "[144 rows x 6 columns]"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3935,8 +4717,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
-   "metadata": {},
+   "execution_count": 61,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.908933Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.908933Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.918583Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.918583Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4077,7 +4866,7 @@
        "[144 rows x 5 columns]"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4089,8 +4878,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "metadata": {},
+   "execution_count": 62,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.920633Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.920633Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.932562Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.931557Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4183,7 +4979,7 @@
        "max      4.400000    6.900000    2.500000"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4198,8 +4994,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {},
+   "execution_count": 63,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.934566Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.934566Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.942665Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.942665Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4283,7 +5086,7 @@
        "max      6.900000    2.500000"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4295,8 +5098,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
-   "metadata": {},
+   "execution_count": 64,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.944711Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.944711Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.950945Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.950945Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4368,7 +5178,7 @@
        "4  1.4  0.1  Iris-setosa"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4379,8 +5189,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {},
+   "execution_count": 65,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.952953Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.952953Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.960492Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.960492Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4464,7 +5281,7 @@
        "4  5.0  3.6  1.4  0.2  Iris-setosa"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4477,8 +5294,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
-   "metadata": {},
+   "execution_count": 66,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.962752Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.962752Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.978146Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.977138Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4631,7 +5455,7 @@
        "[150 rows x 6 columns]"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4645,8 +5469,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
-   "metadata": {},
+   "execution_count": 67,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:38.983144Z",
+     "iopub.status.busy": "2026-07-25T05:19:38.983144Z",
+     "iopub.status.idle": "2026-07-25T05:19:38.998948Z",
+     "shell.execute_reply": "2026-07-25T05:19:38.997923Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -4676,132 +5507,143 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
-   "metadata": {},
+   "execution_count": 68,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:39.002933Z",
+     "iopub.status.busy": "2026-07-25T05:19:39.001933Z",
+     "iopub.status.idle": "2026-07-25T05:19:39.023282Z",
+     "shell.execute_reply": "2026-07-25T05:19:39.022276Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "sl\n",
       "5.0    10\n",
-      "6.3     9\n",
       "5.1     9\n",
-      "6.7     8\n",
+      "6.3     9\n",
       "5.7     8\n",
-      "5.5     7\n",
+      "6.7     8\n",
       "5.8     7\n",
+      "5.5     7\n",
       "6.4     7\n",
-      "6.0     6\n",
       "4.9     6\n",
-      "6.1     6\n",
       "5.4     6\n",
+      "6.1     6\n",
+      "6.0     6\n",
       "5.6     6\n",
-      "6.5     5\n",
       "4.8     5\n",
+      "6.5     5\n",
+      "6.2     4\n",
       "7.7     4\n",
       "6.9     4\n",
-      "5.2     4\n",
-      "6.2     4\n",
       "4.6     4\n",
+      "5.2     4\n",
+      "5.9     3\n",
+      "4.4     3\n",
       "7.2     3\n",
       "6.8     3\n",
-      "4.4     3\n",
-      "5.9     3\n",
       "6.6     2\n",
       "4.7     2\n",
       "7.6     1\n",
       "7.4     1\n",
-      "4.3     1\n",
-      "7.9     1\n",
       "7.3     1\n",
       "7.0     1\n",
-      "4.5     1\n",
-      "5.3     1\n",
       "7.1     1\n",
-      "Name: sl, dtype: int64\n",
+      "5.3     1\n",
+      "4.3     1\n",
+      "4.5     1\n",
+      "7.9     1\n",
+      "Name: count, dtype: int64\n",
       "\n",
+      "sw\n",
       "3.0    26\n",
       "2.8    14\n",
       "3.2    13\n",
-      "3.4    12\n",
       "3.1    12\n",
+      "3.4    12\n",
       "2.9    10\n",
       "2.7     9\n",
       "2.5     8\n",
       "3.5     6\n",
-      "3.8     6\n",
       "3.3     6\n",
+      "3.8     6\n",
       "2.6     5\n",
       "2.3     4\n",
-      "3.6     3\n",
+      "3.7     3\n",
       "2.4     3\n",
       "2.2     3\n",
-      "3.7     3\n",
+      "3.6     3\n",
       "3.9     2\n",
-      "4.2     1\n",
-      "4.1     1\n",
       "4.4     1\n",
-      "2.0     1\n",
       "4.0     1\n",
-      "Name: sw, dtype: int64\n",
+      "4.1     1\n",
+      "4.2     1\n",
+      "2.0     1\n",
+      "Name: count, dtype: int64\n",
       "\n",
+      "pl\n",
       "1.5    14\n",
       "1.4    12\n",
       "5.1     8\n",
       "4.5     8\n",
-      "1.3     7\n",
       "1.6     7\n",
+      "1.3     7\n",
       "5.6     6\n",
-      "4.0     5\n",
-      "4.9     5\n",
       "4.7     5\n",
-      "4.8     4\n",
-      "1.7     4\n",
-      "4.4     4\n",
+      "4.9     5\n",
+      "4.0     5\n",
       "4.2     4\n",
       "5.0     4\n",
+      "4.4     4\n",
+      "4.8     4\n",
+      "1.7     4\n",
+      "3.9     3\n",
+      "4.6     3\n",
+      "5.7     3\n",
       "4.1     3\n",
       "5.5     3\n",
-      "4.6     3\n",
       "6.1     3\n",
-      "5.7     3\n",
-      "3.9     3\n",
       "5.8     3\n",
-      "1.2     2\n",
-      "1.9     2\n",
+      "3.3     2\n",
+      "5.4     2\n",
       "6.7     2\n",
-      "3.5     2\n",
+      "5.3     2\n",
       "5.9     2\n",
       "6.0     2\n",
-      "5.4     2\n",
-      "5.3     2\n",
-      "3.3     2\n",
+      "1.2     2\n",
       "4.3     2\n",
+      "1.9     2\n",
+      "3.5     2\n",
       "5.2     2\n",
-      "6.3     1\n",
-      "1.1     1\n",
-      "6.4     1\n",
-      "3.6     1\n",
-      "3.7     1\n",
       "3.0     1\n",
+      "1.1     1\n",
+      "3.7     1\n",
       "3.8     1\n",
       "6.6     1\n",
-      "6.9     1\n",
+      "6.3     1\n",
       "1.0     1\n",
-      "Name: pl, dtype: int64\n",
+      "6.9     1\n",
+      "3.6     1\n",
+      "6.4     1\n",
+      "Name: count, dtype: int64\n",
       "\n",
+      "pw\n",
       "0.2    28\n",
       "1.3    13\n",
-      "1.5    12\n",
       "1.8    12\n",
+      "1.5    12\n",
       "1.4     8\n",
       "2.3     8\n",
       "1.0     7\n",
-      "0.3     7\n",
       "0.4     7\n",
+      "0.3     7\n",
       "0.1     6\n",
-      "2.0     6\n",
       "2.1     6\n",
+      "2.0     6\n",
       "1.2     5\n",
       "1.9     5\n",
       "1.6     4\n",
@@ -4812,62 +5654,64 @@
       "1.7     2\n",
       "0.6     1\n",
       "0.5     1\n",
-      "Name: pw, dtype: int64\n",
+      "Name: count, dtype: int64\n",
       "\n",
-      "Iris-virginica     50\n",
+      "flower_type\n",
       "Iris-setosa        50\n",
       "Iris-versicolor    50\n",
-      "Name: flower_type, dtype: int64\n",
+      "Iris-virginica     50\n",
+      "Name: count, dtype: int64\n",
       "\n",
+      "diff_pl_pw\n",
       "3.0    14\n",
       "1.2    10\n",
       "1.1     7\n",
       "1.0     6\n",
-      "2.8     6\n",
       "2.7     6\n",
+      "2.8     6\n",
       "1.3     6\n",
       "1.4     5\n",
       "3.2     5\n",
-      "1.4     5\n",
       "3.2     5\n",
+      "1.4     5\n",
       "2.9     4\n",
       "3.1     4\n",
-      "3.3     3\n",
-      "3.3     3\n",
-      "1.1     3\n",
+      "3.6     3\n",
       "2.3     3\n",
-      "4.2     3\n",
-      "4.5     3\n",
-      "3.1     3\n",
-      "3.4     3\n",
       "3.4     3\n",
       "3.5     3\n",
+      "4.2     3\n",
       "2.5     3\n",
-      "3.6     3\n",
-      "1.3     2\n",
-      "1.5     2\n",
+      "3.3     3\n",
+      "3.1     3\n",
+      "4.5     3\n",
+      "3.4     3\n",
+      "1.1     3\n",
+      "3.3     3\n",
+      "3.8     2\n",
+      "3.5     2\n",
+      "3.7     2\n",
       "2.7     2\n",
       "3.1     2\n",
-      "3.8     2\n",
-      "3.7     2\n",
-      "3.5     2\n",
+      "1.3     2\n",
       "3.0     2\n",
-      "4.0     1\n",
-      "3.4     1\n",
-      "1.9     1\n",
-      "0.8     1\n",
-      "4.2     1\n",
-      "4.6     1\n",
-      "1.2     1\n",
-      "1.7     1\n",
-      "0.9     1\n",
-      "3.6     1\n",
+      "1.5     2\n",
       "2.9     1\n",
       "4.7     1\n",
+      "3.4     1\n",
       "4.4     1\n",
+      "0.9     1\n",
+      "4.2     1\n",
       "3.6     1\n",
+      "4.0     1\n",
+      "4.6     1\n",
+      "0.8     1\n",
+      "1.7     1\n",
+      "1.2     1\n",
       "3.8     1\n",
-      "Name: diff_pl_pw, dtype: int64\n",
+      "1.9     1\n",
+      "3.6     1\n",
+      "Name: count, dtype: int64\n",
       "\n"
      ]
     }
@@ -4881,8 +5725,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
-   "metadata": {},
+   "execution_count": 69,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:39.026798Z",
+     "iopub.status.busy": "2026-07-25T05:19:39.025791Z",
+     "iopub.status.idle": "2026-07-25T05:19:39.042958Z",
+     "shell.execute_reply": "2026-07-25T05:19:39.042958Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4894,7 +5745,7 @@
        "Name: pl, dtype: float64"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4906,8 +5757,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
-   "metadata": {},
+   "execution_count": 70,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:39.047185Z",
+     "iopub.status.busy": "2026-07-25T05:19:39.046180Z",
+     "iopub.status.idle": "2026-07-25T05:19:39.057215Z",
+     "shell.execute_reply": "2026-07-25T05:19:39.056207Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4919,7 +5777,7 @@
        "Name: pw, dtype: float64"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4930,8 +5788,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
-   "metadata": {},
+   "execution_count": 71,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:39.063235Z",
+     "iopub.status.busy": "2026-07-25T05:19:39.062214Z",
+     "iopub.status.idle": "2026-07-25T05:19:39.083329Z",
+     "shell.execute_reply": "2026-07-25T05:19:39.080317Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -4943,7 +5808,7 @@
        "Name: sw, dtype: float64"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4954,8 +5819,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
-   "metadata": {},
+   "execution_count": 72,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:39.091368Z",
+     "iopub.status.busy": "2026-07-25T05:19:39.091368Z",
+     "iopub.status.idle": "2026-07-25T05:19:39.128477Z",
+     "shell.execute_reply": "2026-07-25T05:19:39.126462Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -5039,7 +5911,7 @@
        "4  5.0  3.6  1.4  0.2         0"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5069,8 +5941,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
-   "metadata": {},
+   "execution_count": 73,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T05:19:39.131514Z",
+     "iopub.status.busy": "2026-07-25T05:19:39.131514Z",
+     "iopub.status.idle": "2026-07-25T05:19:39.150800Z",
+     "shell.execute_reply": "2026-07-25T05:19:39.148640Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -5082,7 +5961,7 @@
        "Name: sl, dtype: int64"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5108,7 +5987,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/Basics of ML and DL/ML/Pandas/Pandas.ipynb
+++ b/Basics of ML and DL/ML/Pandas/Pandas.ipynb
@@ -5,10 +5,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:36.847737Z",
-     "iopub.status.busy": "2026-07-25T05:19:36.847737Z",
-     "iopub.status.idle": "2026-07-25T05:19:36.854255Z",
-     "shell.execute_reply": "2026-07-25T05:19:36.853740Z"
+     "iopub.execute_input": "2026-07-29T08:58:07.691133Z",
+     "iopub.status.busy": "2026-07-29T08:58:07.690119Z",
+     "iopub.status.idle": "2026-07-29T08:58:07.699642Z",
+     "shell.execute_reply": "2026-07-29T08:58:07.698960Z"
     }
    },
    "outputs": [],
@@ -22,10 +22,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:36.858766Z",
-     "iopub.status.busy": "2026-07-25T05:19:36.857763Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.418547Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.418547Z"
+     "iopub.execute_input": "2026-07-29T08:58:07.703745Z",
+     "iopub.status.busy": "2026-07-29T08:58:07.703745Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.016486Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.015476Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.421554Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.420554Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.429143Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.429143Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.019522Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.019522Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.042190Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.041175Z"
     }
    },
    "outputs": [],
@@ -57,10 +57,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.431158Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.431158Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.445608Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.444088Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.045188Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.044293Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.063517Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.062569Z"
     }
    },
    "outputs": [
@@ -94,10 +94,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.479551Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.479551Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.492047Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.491032Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.106520Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.105481Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.129830Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.128804Z"
     }
    },
    "outputs": [
@@ -254,10 +254,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.494045Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.493045Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.504863Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.503850Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.133965Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.132964Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.150136Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.150136Z"
     }
    },
    "outputs": [
@@ -416,10 +416,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.509413Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.509413Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.521637Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.519629Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.153647Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.153647Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.161106Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.160099Z"
     }
    },
    "outputs": [],
@@ -433,10 +433,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.525635Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.525635Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.537114Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.536099Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.163621Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.163621Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.173521Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.172512Z"
     }
    },
    "outputs": [
@@ -536,10 +536,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.540104Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.539104Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.545707Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.544190Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.176522Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.175520Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.182465Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.181446Z"
     }
    },
    "outputs": [
@@ -563,10 +563,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.547712Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.546714Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.552140Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.551134Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.184463Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.184463Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.187703Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.187703Z"
     }
    },
    "outputs": [],
@@ -580,10 +580,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.554142Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.554142Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.559796Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.558657Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.190710Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.189716Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.195226Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.194711Z"
     }
    },
    "outputs": [],
@@ -599,10 +599,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.562794Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.561793Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.573121Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.572117Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.198750Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.197747Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.208404Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.207391Z"
     }
    },
    "outputs": [
@@ -702,10 +702,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.575627Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.575627Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.583924Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.582919Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.211489Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.210413Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.220544Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.220544Z"
     }
    },
    "outputs": [
@@ -787,10 +787,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.587187Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.585977Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.594578Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.594578Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.223662Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.223662Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.234070Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.233010Z"
     }
    },
    "outputs": [
@@ -890,10 +890,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.596715Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.596715Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.603885Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.603885Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.236740Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.235130Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.246422Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.245897Z"
     }
    },
    "outputs": [
@@ -975,10 +975,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.605892Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.605892Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.609767Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.609767Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.249545Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.249545Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.255639Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.254431Z"
     }
    },
    "outputs": [
@@ -1002,10 +1002,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.611947Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.611947Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.617072Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.616067Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.257895Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.256741Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.264941Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.264941Z"
     }
    },
    "outputs": [
@@ -1029,10 +1029,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.618073Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.618073Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.621609Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.621609Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.268579Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.267578Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.271913Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.271913Z"
     }
    },
    "outputs": [],
@@ -1047,10 +1047,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.623626Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.623626Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.627249Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.627249Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.274923Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.274923Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.281455Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.281455Z"
     }
    },
    "outputs": [
@@ -1074,10 +1074,10 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.629255Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.629255Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.634323Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.634323Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.284766Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.284766Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.292610Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.291600Z"
     }
    },
    "outputs": [
@@ -1106,10 +1106,10 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.636853Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.635841Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.647962Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.647962Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.294613Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.294613Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.315240Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.314452Z"
     }
    },
    "outputs": [
@@ -1227,10 +1227,10 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.650213Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.650213Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.653489Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.653489Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.317772Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.317772Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.322099Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.322099Z"
     }
    },
    "outputs": [],
@@ -1248,10 +1248,10 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.654494Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.654494Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.669083Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.669083Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.325116Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.325116Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.353368Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.351757Z"
     }
    },
    "outputs": [
@@ -1406,10 +1406,10 @@
    "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.671088Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.671088Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.677265Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.676508Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.356414Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.355400Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.364234Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.363223Z"
     }
    },
    "outputs": [
@@ -1447,10 +1447,10 @@
    "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.678446Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.678446Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.685995Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.685475Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.366742Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.366742Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.374025Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.373016Z"
     }
    },
    "outputs": [
@@ -1487,10 +1487,10 @@
    "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.688008Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.687001Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.693951Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.693951Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.376542Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.376542Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.384890Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.384890Z"
     }
    },
    "outputs": [
@@ -1556,10 +1556,10 @@
    "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.695964Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.695964Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.702428Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.702428Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.387409Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.387409Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.398181Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.396633Z"
     }
    },
    "outputs": [
@@ -1631,10 +1631,10 @@
    "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.704439Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.704439Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.712803Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.712803Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.400169Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.400169Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.411116Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.410107Z"
     }
    },
    "outputs": [
@@ -1791,10 +1791,10 @@
    "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.714815Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.714815Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.720575Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.720575Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.414115Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.413116Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.422162Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.421652Z"
     }
    },
    "outputs": [
@@ -1823,10 +1823,10 @@
    "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.722587Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.722587Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.729153Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.729153Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.425174Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.425174Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.438223Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.437200Z"
     }
    },
    "outputs": [
@@ -1859,10 +1859,10 @@
    "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.731418Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.731418Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.738307Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.738307Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.440209Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.440209Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.450930Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.449906Z"
     }
    },
    "outputs": [
@@ -1964,10 +1964,10 @@
    "execution_count": 32,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.740316Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.740316Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.743365Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.743365Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.452932Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.452932Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.457474Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.456452Z"
     }
    },
    "outputs": [],
@@ -1980,10 +1980,10 @@
    "execution_count": 33,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.745639Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.744636Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.753507Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.753507Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.459483Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.459483Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.469527Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.469527Z"
     }
    },
    "outputs": [
@@ -2086,10 +2086,10 @@
    "execution_count": 34,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.756023Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.754513Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.763412Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.763412Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.471853Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.471853Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.481425Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.481425Z"
     }
    },
    "outputs": [
@@ -2193,10 +2193,10 @@
    "execution_count": 35,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.764417Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.764417Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.768982Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.768982Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.484795Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.483795Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.488838Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.487831Z"
     }
    },
    "outputs": [],
@@ -2209,10 +2209,10 @@
    "execution_count": 36,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.771303Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.771303Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.773746Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.773746Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.490841Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.490841Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.494111Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.494111Z"
     }
    },
    "outputs": [],
@@ -2227,10 +2227,10 @@
    "execution_count": 37,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.775760Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.775760Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.783779Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.783272Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.496636Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.496636Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.505656Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.505656Z"
     }
    },
    "outputs": [
@@ -2334,10 +2334,10 @@
    "execution_count": 38,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.785791Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.785791Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.793946Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.793946Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.509143Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.508137Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.519241Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.518226Z"
     }
    },
    "outputs": [
@@ -2438,10 +2438,10 @@
    "execution_count": 39,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.795711Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.795711Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.805752Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.805229Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.522243Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.521243Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.534956Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.533934Z"
     }
    },
    "outputs": [
@@ -2589,10 +2589,10 @@
    "execution_count": 40,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.807758Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.807758Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.811267Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.811267Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.538479Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.537492Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.544443Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.543432Z"
     }
    },
    "outputs": [
@@ -2620,10 +2620,10 @@
    "execution_count": 41,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.813278Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.813278Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.817341Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.816334Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.546552Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.546552Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.550874Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.549864Z"
     }
    },
    "outputs": [],
@@ -2636,17 +2636,17 @@
    "execution_count": 42,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.819344Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.819344Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.823438Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.823438Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.552939Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.552939Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.557637Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.557637Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1"
+       "np.int64(1)"
       ]
      },
      "execution_count": 42,
@@ -2663,10 +2663,10 @@
    "execution_count": 43,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.824950Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.824950Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.832975Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.832975Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.560016Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.560016Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.569082Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.568066Z"
     }
    },
    "outputs": [
@@ -2766,10 +2766,10 @@
    "execution_count": 44,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.835850Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.835850Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.843092Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.843092Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.571083Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.570108Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.579627Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.579627Z"
     }
    },
    "outputs": [
@@ -2873,10 +2873,10 @@
    "execution_count": 45,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.845924Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.844099Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.851117Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.850611Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.581854Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.581854Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.587879Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.587373Z"
     }
    },
    "outputs": [
@@ -2900,10 +2900,10 @@
    "execution_count": 46,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.853123Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.853123Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.860828Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.860828Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.589885Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.589885Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.600327Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.600327Z"
     }
    },
    "outputs": [
@@ -3006,10 +3006,10 @@
    "execution_count": 47,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.862834Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.862834Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.867089Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.865837Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.603342Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.603342Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.607914Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.606896Z"
     }
    },
    "outputs": [],
@@ -3022,10 +3022,10 @@
    "execution_count": 48,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.869115Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.868090Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.874303Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.874303Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.610911Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.610911Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.617777Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.617777Z"
     }
    },
    "outputs": [
@@ -3060,10 +3060,10 @@
    "execution_count": 49,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.876831Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.875824Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.886861Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.886861Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.620782Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.620782Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.633685Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.632670Z"
     }
    },
    "outputs": [
@@ -3221,10 +3221,10 @@
    "execution_count": 50,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.889044Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.889044Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.903448Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.903448Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.635687Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.635687Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.658467Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.657456Z"
     }
    },
    "outputs": [
@@ -3614,10 +3614,10 @@
    "execution_count": 51,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.905958Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.905958Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.920816Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.919861Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.662466Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.661464Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.680178Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.680178Z"
     }
    },
    "outputs": [
@@ -4050,10 +4050,10 @@
    "execution_count": 52,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.922373Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.922373Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.935725Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.935208Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.683184Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.683184Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.697774Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.696767Z"
     }
    },
    "outputs": [
@@ -4171,10 +4171,10 @@
    "execution_count": 53,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.937759Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.937759Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.943103Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.943103Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.699774Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.699774Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.706358Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.705840Z"
     }
    },
    "outputs": [
@@ -4204,10 +4204,10 @@
    "execution_count": 54,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.945627Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.944114Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.949633Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.949633Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.709366Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.709366Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.714424Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.714424Z"
     }
    },
    "outputs": [
@@ -4233,10 +4233,10 @@
    "execution_count": 55,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.952018Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.952018Z",
-     "iopub.status.idle": "2026-07-25T05:19:37.956528Z",
-     "shell.execute_reply": "2026-07-25T05:19:37.956016Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.718014Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.718014Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.723063Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.723063Z"
     }
    },
    "outputs": [
@@ -4262,40 +4262,26 @@
    "execution_count": 56,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:37.957531Z",
-     "iopub.status.busy": "2026-07-25T05:19:37.957531Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.855622Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.855622Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.726449Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.726449Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.734006Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.732998Z"
     }
    },
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "0",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexes\\base.py:3812\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3811\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m3812\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43m_engine\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43mget_loc\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mcasted_key\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n\u001b[32m   3813\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:167\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m--> \u001b[39m\u001b[32m167\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:196\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m--> \u001b[39m\u001b[32m196\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:2606\u001b[39m, in \u001b[36mpandas._libs.hashtable.Int64HashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m2606\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:2630\u001b[39m, in \u001b[36mpandas._libs.hashtable.Int64HashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m2630\u001b[39m \u001b[33m'Could not get source, probably due dynamically evaluated source code.'\u001b[39m\n",
-      "\u001b[31mKeyError\u001b[39m: 0",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[56]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m print(df.loc[\u001b[32m0\u001b[39m]) \u001b[38;5;66;03m# error dega\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexing.py:1192\u001b[39m, in \u001b[36m_LocationIndexer.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   1190\u001b[39m maybe_callable = com.apply_if_callable(key, \u001b[38;5;28mself\u001b[39m.obj)\n\u001b[32m   1191\u001b[39m maybe_callable = \u001b[38;5;28mself\u001b[39m._check_deprecated_callable_usage(key, maybe_callable)\n\u001b[32m-> \u001b[39m\u001b[32m1192\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43m_getitem_axis\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mmaybe_callable\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m=\u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexing.py:1432\u001b[39m, in \u001b[36m_LocIndexer._getitem_axis\u001b[39m\u001b[34m(self, key, axis)\u001b[39m\n\u001b[32m   1430\u001b[39m \u001b[38;5;66;03m# fall thru to straight lookup\u001b[39;00m\n\u001b[32m   1431\u001b[39m \u001b[38;5;28mself\u001b[39m._validate_key(key, axis)\n\u001b[32m-> \u001b[39m\u001b[32m1432\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43m_get_label\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mkey\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m=\u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexing.py:1382\u001b[39m, in \u001b[36m_LocIndexer._get_label\u001b[39m\u001b[34m(self, label, axis)\u001b[39m\n\u001b[32m   1380\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_get_label\u001b[39m(\u001b[38;5;28mself\u001b[39m, label, axis: AxisInt):\n\u001b[32m   1381\u001b[39m     \u001b[38;5;66;03m# GH#5567 this will fail if the label is not present in the axis.\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1382\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mself\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43mobj\u001b[39;49m\u001b[30;43m.\u001b[39;49m\u001b[30;43mxs\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43mlabel\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m=\u001b[39;49m\u001b[30;43maxis\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\generic.py:4323\u001b[39m, in \u001b[36mNDFrame.xs\u001b[39m\u001b[34m(self, key, axis, level, drop_level)\u001b[39m\n\u001b[32m   4319\u001b[39m                     new_index = index[loc : loc + \u001b[32m1\u001b[39m]\n\u001b[32m   4320\u001b[39m                 \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   4321\u001b[39m                     new_index = index[loc]\n\u001b[32m   4322\u001b[39m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m4323\u001b[39m             loc = index.get_loc(key)\n\u001b[32m   4324\u001b[39m \n\u001b[32m   4325\u001b[39m             \u001b[38;5;28;01mif\u001b[39;00m isinstance(loc, np.ndarray):\n\u001b[32m   4326\u001b[39m                 \u001b[38;5;28;01mif\u001b[39;00m loc.dtype == np.bool_:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pandas\\core\\indexes\\base.py:3819\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3814\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(casted_key, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[32m   3815\u001b[39m         \u001b[38;5;28misinstance\u001b[39m(casted_key, abc.Iterable)\n\u001b[32m   3816\u001b[39m         \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28many\u001b[39m(\u001b[38;5;28misinstance\u001b[39m(x, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m casted_key)\n\u001b[32m   3817\u001b[39m     ):\n\u001b[32m   3818\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[32m-> \u001b[39m\u001b[32m3819\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m   3820\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[32m   3821\u001b[39m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[32m   3822\u001b[39m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[32m   3823\u001b[39m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n\u001b[32m   3824\u001b[39m     \u001b[38;5;28mself\u001b[39m._check_indexing_error(key)\n",
-      "\u001b[31mKeyError\u001b[39m: 0"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KeyError: index 0 not present as expected\n"
      ]
     }
    ],
    "source": [
-    "print(df.loc[0]) # error dega"
+    "try:\n",
+    "    print(df.loc[0]) # error dega\n",
+    "except KeyError:\n",
+    "    print('KeyError: index 0 not present as expected')"
    ]
   },
   {
@@ -4303,10 +4289,10 @@
    "execution_count": 57,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.858630Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.857633Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.874243Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.873234Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.735008Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.735008Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.748403Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.747116Z"
     }
    },
    "outputs": [
@@ -4410,10 +4396,10 @@
    "execution_count": 58,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.876760Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.876760Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.885799Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.885799Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.750412Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.750412Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.763870Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.762764Z"
     }
    },
    "outputs": [
@@ -4513,10 +4499,10 @@
    "execution_count": 59,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.887816Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.887816Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.892063Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.892063Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.766551Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.766551Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.772951Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.771935Z"
     }
    },
    "outputs": [
@@ -4543,10 +4529,10 @@
    "execution_count": 60,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.894068Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.894068Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.906925Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.906925Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.774951Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.774951Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.788787Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.787579Z"
     }
    },
    "outputs": [
@@ -4720,10 +4706,10 @@
    "execution_count": 61,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.908933Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.908933Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.918583Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.918583Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.790796Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.790796Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.805450Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.805450Z"
     }
    },
    "outputs": [
@@ -4881,10 +4867,10 @@
    "execution_count": 62,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.920633Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.920633Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.932562Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.931557Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.809086Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.809086Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.821718Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.821718Z"
     }
    },
    "outputs": [
@@ -4997,10 +4983,10 @@
    "execution_count": 63,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.934566Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.934566Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.942665Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.942665Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.824727Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.824727Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.836264Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.836264Z"
     }
    },
    "outputs": [
@@ -5101,10 +5087,10 @@
    "execution_count": 64,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.944711Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.944711Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.950945Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.950945Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.839648Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.839648Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.849209Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.848191Z"
     }
    },
    "outputs": [
@@ -5192,10 +5178,10 @@
    "execution_count": 65,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.952953Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.952953Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.960492Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.960492Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.851234Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.851234Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.860767Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.860767Z"
     }
    },
    "outputs": [
@@ -5297,10 +5283,10 @@
    "execution_count": 66,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.962752Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.962752Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.978146Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.977138Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.863940Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.863940Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.877980Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.876972Z"
     }
    },
    "outputs": [
@@ -5472,10 +5458,10 @@
    "execution_count": 67,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:38.983144Z",
-     "iopub.status.busy": "2026-07-25T05:19:38.983144Z",
-     "iopub.status.idle": "2026-07-25T05:19:38.998948Z",
-     "shell.execute_reply": "2026-07-25T05:19:38.997923Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.879981Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.879981Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.890301Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.890301Z"
     }
    },
    "outputs": [
@@ -5486,7 +5472,13 @@
       "[5.1 4.9 4.7 4.6 5.  5.4 4.4 4.8 4.3 5.8 5.7 5.2 5.5 4.5 5.3 7.  6.4 6.9\n",
       " 6.5 6.3 6.6 5.9 6.  6.1 5.6 6.7 6.2 6.8 7.1 7.6 7.3 7.2 7.7 7.4 7.9] \t 35\n",
       "[3.5 3.  3.2 3.1 3.6 3.9 3.4 2.9 3.7 4.  4.4 3.8 3.3 4.1 4.2 2.3 2.8 2.4\n",
-      " 2.7 2.  2.2 2.5 2.6] \t 23\n",
+      " 2.7 2.  2.2 2.5 2.6] \t 23\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[1.4 1.3 1.5 1.7 1.6 1.1 1.2 1.  1.9 4.7 4.5 4.9 4.  4.6 3.3 3.9 3.5 4.2\n",
       " 3.6 4.4 4.1 4.8 4.3 5.  3.8 3.7 5.1 3.  6.  5.9 5.6 5.8 6.6 6.3 6.1 5.3\n",
       " 5.5 6.7 6.9 5.7 6.4 5.4 5.2] \t 43\n",
@@ -5510,10 +5502,10 @@
    "execution_count": 68,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:39.002933Z",
-     "iopub.status.busy": "2026-07-25T05:19:39.001933Z",
-     "iopub.status.idle": "2026-07-25T05:19:39.023282Z",
-     "shell.execute_reply": "2026-07-25T05:19:39.022276Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.893692Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.893692Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.907894Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.906887Z"
     }
    },
    "outputs": [
@@ -5523,39 +5515,39 @@
      "text": [
       "sl\n",
       "5.0    10\n",
-      "5.1     9\n",
       "6.3     9\n",
-      "5.7     8\n",
+      "5.1     9\n",
       "6.7     8\n",
-      "5.8     7\n",
-      "5.5     7\n",
+      "5.7     8\n",
       "6.4     7\n",
+      "5.5     7\n",
+      "5.8     7\n",
       "4.9     6\n",
-      "5.4     6\n",
-      "6.1     6\n",
       "6.0     6\n",
+      "5.4     6\n",
       "5.6     6\n",
-      "4.8     5\n",
+      "6.1     6\n",
       "6.5     5\n",
-      "6.2     4\n",
+      "4.8     5\n",
       "7.7     4\n",
       "6.9     4\n",
       "4.6     4\n",
       "5.2     4\n",
-      "5.9     3\n",
+      "6.2     4\n",
       "4.4     3\n",
       "7.2     3\n",
+      "5.9     3\n",
       "6.8     3\n",
-      "6.6     2\n",
       "4.7     2\n",
+      "6.6     2\n",
+      "4.3     1\n",
+      "7.0     1\n",
+      "5.3     1\n",
+      "4.5     1\n",
+      "7.1     1\n",
+      "7.3     1\n",
       "7.6     1\n",
       "7.4     1\n",
-      "7.3     1\n",
-      "7.0     1\n",
-      "7.1     1\n",
-      "5.3     1\n",
-      "4.3     1\n",
-      "4.5     1\n",
       "7.9     1\n",
       "Name: count, dtype: int64\n",
       "\n",
@@ -5563,83 +5555,83 @@
       "3.0    26\n",
       "2.8    14\n",
       "3.2    13\n",
-      "3.1    12\n",
       "3.4    12\n",
+      "3.1    12\n",
       "2.9    10\n",
       "2.7     9\n",
       "2.5     8\n",
-      "3.5     6\n",
       "3.3     6\n",
+      "3.5     6\n",
       "3.8     6\n",
       "2.6     5\n",
       "2.3     4\n",
       "3.7     3\n",
-      "2.4     3\n",
-      "2.2     3\n",
       "3.6     3\n",
+      "2.2     3\n",
+      "2.4     3\n",
       "3.9     2\n",
       "4.4     1\n",
-      "4.0     1\n",
-      "4.1     1\n",
       "4.2     1\n",
+      "4.1     1\n",
+      "4.0     1\n",
       "2.0     1\n",
       "Name: count, dtype: int64\n",
       "\n",
       "pl\n",
       "1.5    14\n",
       "1.4    12\n",
-      "5.1     8\n",
       "4.5     8\n",
-      "1.6     7\n",
+      "5.1     8\n",
       "1.3     7\n",
+      "1.6     7\n",
       "5.6     6\n",
-      "4.7     5\n",
       "4.9     5\n",
       "4.0     5\n",
-      "4.2     4\n",
+      "4.7     5\n",
+      "1.7     4\n",
+      "4.8     4\n",
       "5.0     4\n",
       "4.4     4\n",
-      "4.8     4\n",
-      "1.7     4\n",
-      "3.9     3\n",
-      "4.6     3\n",
-      "5.7     3\n",
+      "4.2     4\n",
       "4.1     3\n",
+      "3.9     3\n",
+      "5.8     3\n",
+      "5.7     3\n",
       "5.5     3\n",
       "6.1     3\n",
-      "5.8     3\n",
-      "3.3     2\n",
+      "4.6     3\n",
+      "1.9     2\n",
+      "5.2     2\n",
       "5.4     2\n",
+      "1.2     2\n",
+      "3.3     2\n",
+      "3.5     2\n",
       "6.7     2\n",
       "5.3     2\n",
+      "4.3     2\n",
       "5.9     2\n",
       "6.0     2\n",
-      "1.2     2\n",
-      "4.3     2\n",
-      "1.9     2\n",
-      "3.5     2\n",
-      "5.2     2\n",
-      "3.0     1\n",
+      "1.0     1\n",
       "1.1     1\n",
       "3.7     1\n",
       "3.8     1\n",
-      "6.6     1\n",
-      "6.3     1\n",
-      "1.0     1\n",
-      "6.9     1\n",
       "3.6     1\n",
+      "3.0     1\n",
+      "6.3     1\n",
+      "6.6     1\n",
+      "6.9     1\n",
       "6.4     1\n",
       "Name: count, dtype: int64\n",
       "\n",
       "pw\n",
       "0.2    28\n",
       "1.3    13\n",
-      "1.8    12\n",
       "1.5    12\n",
+      "1.8    12\n",
       "1.4     8\n",
       "2.3     8\n",
-      "1.0     7\n",
       "0.4     7\n",
+      "1.0     7\n",
       "0.3     7\n",
       "0.1     6\n",
       "2.1     6\n",
@@ -5649,8 +5641,8 @@
       "1.6     4\n",
       "2.5     3\n",
       "2.2     3\n",
-      "2.4     3\n",
       "1.1     3\n",
+      "2.4     3\n",
       "1.7     2\n",
       "0.6     1\n",
       "0.5     1\n",
@@ -5666,50 +5658,50 @@
       "3.0    14\n",
       "1.2    10\n",
       "1.1     7\n",
+      "1.3     6\n",
       "1.0     6\n",
       "2.7     6\n",
       "2.8     6\n",
-      "1.3     6\n",
       "1.4     5\n",
       "3.2     5\n",
       "3.2     5\n",
       "1.4     5\n",
-      "2.9     4\n",
       "3.1     4\n",
-      "3.6     3\n",
-      "2.3     3\n",
-      "3.4     3\n",
-      "3.5     3\n",
-      "4.2     3\n",
-      "2.5     3\n",
+      "2.9     4\n",
       "3.3     3\n",
-      "3.1     3\n",
-      "4.5     3\n",
       "3.4     3\n",
       "1.1     3\n",
+      "3.4     3\n",
+      "3.5     3\n",
       "3.3     3\n",
-      "3.8     2\n",
+      "2.3     3\n",
+      "4.2     3\n",
+      "4.5     3\n",
+      "3.1     3\n",
+      "2.5     3\n",
+      "3.6     3\n",
       "3.5     2\n",
       "3.7     2\n",
-      "2.7     2\n",
-      "3.1     2\n",
-      "1.3     2\n",
       "3.0     2\n",
       "1.5     2\n",
-      "2.9     1\n",
-      "4.7     1\n",
-      "3.4     1\n",
-      "4.4     1\n",
+      "1.3     2\n",
+      "2.7     2\n",
+      "3.1     2\n",
+      "3.8     2\n",
       "0.9     1\n",
-      "4.2     1\n",
-      "3.6     1\n",
-      "4.0     1\n",
-      "4.6     1\n",
       "0.8     1\n",
       "1.7     1\n",
       "1.2     1\n",
+      "2.9     1\n",
       "3.8     1\n",
       "1.9     1\n",
+      "4.0     1\n",
+      "4.6     1\n",
+      "3.6     1\n",
+      "4.7     1\n",
+      "4.2     1\n",
+      "4.4     1\n",
+      "3.4     1\n",
       "3.6     1\n",
       "Name: count, dtype: int64\n",
       "\n"
@@ -5728,10 +5720,10 @@
    "execution_count": 69,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:39.026798Z",
-     "iopub.status.busy": "2026-07-25T05:19:39.025791Z",
-     "iopub.status.idle": "2026-07-25T05:19:39.042958Z",
-     "shell.execute_reply": "2026-07-25T05:19:39.042958Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.909908Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.909908Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.919925Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.918909Z"
     }
    },
    "outputs": [
@@ -5760,10 +5752,10 @@
    "execution_count": 70,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:39.047185Z",
-     "iopub.status.busy": "2026-07-25T05:19:39.046180Z",
-     "iopub.status.idle": "2026-07-25T05:19:39.057215Z",
-     "shell.execute_reply": "2026-07-25T05:19:39.056207Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.921927Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.921927Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.930467Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.930467Z"
     }
    },
    "outputs": [
@@ -5791,10 +5783,10 @@
    "execution_count": 71,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:39.063235Z",
-     "iopub.status.busy": "2026-07-25T05:19:39.062214Z",
-     "iopub.status.idle": "2026-07-25T05:19:39.083329Z",
-     "shell.execute_reply": "2026-07-25T05:19:39.080317Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.933970Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.933970Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.942420Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.941410Z"
     }
    },
    "outputs": [
@@ -5822,10 +5814,10 @@
    "execution_count": 72,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:39.091368Z",
-     "iopub.status.busy": "2026-07-25T05:19:39.091368Z",
-     "iopub.status.idle": "2026-07-25T05:19:39.128477Z",
-     "shell.execute_reply": "2026-07-25T05:19:39.126462Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.945419Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.944420Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.955330Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.955330Z"
     }
    },
    "outputs": [
@@ -5944,10 +5936,10 @@
    "execution_count": 73,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T05:19:39.131514Z",
-     "iopub.status.busy": "2026-07-25T05:19:39.131514Z",
-     "iopub.status.idle": "2026-07-25T05:19:39.150800Z",
-     "shell.execute_reply": "2026-07-25T05:19:39.148640Z"
+     "iopub.execute_input": "2026-07-29T08:58:09.958403Z",
+     "iopub.status.busy": "2026-07-29T08:58:09.958403Z",
+     "iopub.status.idle": "2026-07-29T08:58:09.964262Z",
+     "shell.execute_reply": "2026-07-29T08:58:09.964262Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
Closes #1839


### Description
This PR resolves the `ValueError: The truth value of a Series is ambiguous` bug in the Pandas tutorial notebook (`Basics of ML and DL/ML/Pandas/Pandas.ipynb`). 

### Cause
In Cell 49, the tutorial was using the standard Python logical `and` keyword instead of the element-wise Pandas bitwise `&` operator to filter the `iris` DataFrame:
```python
iris[(iris.sl > 6) and (iris.pl > 5)]
```

Since Pandas Series evaluation with the Python `and` keyword tries to evaluate the truthiness of the entire Series, it raises a `ValueError`.

### Solution
 - Replaced the `and` logical operator with the Pandas bitwise `&` operator:
```python
iris[(iris.sl > 6) & (iris.pl > 5)]
```
 -  Re-executed the notebook cells to refresh and save correct output values.
