### PR TITLE
feat: Add Voice & CLI-Driven System Virtual Assistant (#1984)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Multidisciplinary field combining statistics, ML, computing, and domain expertis
 | 45 | [Scaling Methods](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Different_types_of_scaling_Method) | 46 | [Diseases Prediction](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Diseases_Prediction) | 47 | [Drowsiness Detection](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Driver_Drowsiness_Detection) | 48 | [Duplicate Questions](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Duplicate_Question_pair) |
 | 49 | [Ionosphere EDA](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/EDA-and-Perform-Modelling-on-Ionosphere-Dataset-main) | 50 | [Email Classifier](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Email%20Classifier) | 51 | [Emotion Recognition](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Emotion%20Recognition%20Based%20on%20NLP) | 52 | [Eye Gaze Tracking](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Eye_Gaze_Tracking_Attention_Estimation) |
 | 53 | [Bank Marketing](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Portuguese_Bank_Marketing) | 54 | [Constellation Classification](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Constellation_Classification) | 55 | [Crime Analytics](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Crime_Analytics) | 56 | [CBOW PyTorch](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/CBOW_PyTorch) |
-| 57 | [Mental Health Risk Scorer](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Mental_Health_Text_Analysis_%26_Depression_Risk_Scorer) | | | | |
+| 57 | [Mental Health Risk Scorer](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Mental_Health_Text_Analysis_%26_Depression_Risk_Scorer) | 58 | [Voice & CLI Virtual Assistant](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Voice_CLI_Virtual_Assistant) | | | | |
 
 > 📌 **& many more...** Explore the full repository for 500+ additional projects!
 
@@ -409,6 +409,7 @@ Multidisciplinary field combining statistics, ML, computing, and domain expertis
 | Sales Prediction (Research) | ML | Advanced | [View →](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Sales%20Prediction) |
 | TweetMiner AI | NLP | Beginner | [View →](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/TweetMiner_AI) |
 | Mental Health Risk Scorer | NLP & Transformers | Advanced | [View →](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Mental_Health_Text_Analysis_%26_Depression_Risk_Scorer) |
+| Voice & CLI Virtual Assistant | Speech & Automation | Intermediate | [View →](https://github.com/Niketkumardheeryan/ML-CaPsule/tree/master/Voice_CLI_Virtual_Assistant) |
 
 </details>
 

--- a/Voice_CLI_Virtual_Assistant/README.md
+++ b/Voice_CLI_Virtual_Assistant/README.md
@@ -1,0 +1,262 @@
+# 🎙️ Voice & CLI-Driven System Virtual Assistant
+
+A Python virtual assistant that takes commands **two ways** — spoken into a microphone or
+typed at a command line — and answers with synthesized speech plus text. It fetches live
+intelligence from the web, reads your machine's telemetry, and can drive OS-level actions.
+
+Built for [Issue #1984](https://github.com/Niketkumardheeryan/ML-CaPsule/issues/1984).
+
+---
+
+## 🎯 Goal
+
+Most assistant projects are a single long script that dies the moment a microphone,
+speaker or API key is missing. This one is built the other way round:
+
+* **Multi-modal** — the same command surface works over voice *and* the CLI.
+* **Degrades instead of crashing** — every optional dependency (`pyttsx3`, `SpeechRecognition`,
+  `wikipedia`, `psutil`, `pyautogui`, `pyperclip`) is imported lazily and has a fallback path.
+  With none of them installed, the assistant still starts and answers in text.
+* **Works with zero API keys** — weather comes from `wttr.in` and news from Google News RSS.
+  Export `OPENWEATHER_API_KEY` / `NEWSAPI_KEY` and it upgrades to those providers automatically.
+* **Safe by default** — shutdown / restart / logout sit behind two independent gates.
+* **Testable** — the intent router and every parser are pure functions, covered by
+  **43 offline unit tests**.
+
+---
+
+## ✨ Features
+
+### 🗣️ Speech & NLP layer
+- Time-of-day greetings (morning / afternoon / evening / night).
+- Offline text-to-speech via `pyttsx3`; falls back to printed output.
+- Microphone speech-to-text via `SpeechRecognition`; falls back to typed input.
+- Optional wake word (`hey capsule …`), stripped during normalisation.
+
+### 🌐 Web & knowledge integrations
+- Wikipedia summaries, with a keyless REST fallback when the `wikipedia` package is absent
+  and a readable message on disambiguation.
+- Google search launched in the default browser.
+- YouTube results opened for streaming.
+
+### 📡 Live data orchestration
+- Real-time weather for the configured city (**Jamshedpur** by default), or any city named
+  in the command: `weather in Mumbai`.
+- Top news headlines of the day, numbered for readability.
+
+### 🖥️ System automation engine
+- Clipboard read-back (`pyperclip`, with `pbpaste` / `xclip` / PowerShell fallbacks).
+- Timestamped desktop screenshots — `screenshot_YYYYMMDD_HHMMSS.png`.
+- Battery telemetry: percentage, charging state and estimated runtime remaining.
+
+### ⚙️ OS-level control hooks
+- Media playback through the platform's default player (`open` / `xdg-open` / `os.startfile`).
+- Power controls (shutdown, restart, logout) for Windows, macOS and Linux — **guarded**, see below.
+
+---
+
+## 🔐 Safety model for destructive actions
+
+Power commands are the one genuinely irreversible part of the assistant, so they are behind
+two independent gates:
+
+| Gate | Requirement | If unmet |
+|:----:|-------------|----------|
+| 1 | Opt in with `--allow-power` (or `ASSISTANT_ALLOW_POWER=1`) | The exact command that *would* run is reported; nothing executes |
+| 2 | Type the action name to confirm | The request is cancelled |
+
+```text
+$ python main.py --no-tts --say "shutdown"
+assistant > Power commands are disabled. Restart me with --allow-power to enable
+            'shutdown' (it would run: osascript -e tell app "System Events" to shut down).
+
+$ python main.py --no-tts --allow-power --say "restart"
+Type 'restart' to confirm, anything else cancels: no
+assistant > Cancelled the restart request.
+```
+
+Both gates are covered by unit tests that assert **no command is ever dispatched** unless
+both are satisfied.
+
+---
+
+## 🛠️ Tech Stack
+
+| Package | Role | Required? |
+|---------|------|:---------:|
+| `requests` | weather, news, Wikipedia REST fallback | ✅ |
+| `pyttsx3` | offline text-to-speech | optional |
+| `SpeechRecognition` | microphone speech-to-text | optional |
+| `wikipedia` | Wikipedia summaries | optional |
+| `psutil` | battery telemetry | optional |
+| `pyautogui` | desktop screenshots | optional |
+| `pyperclip` | clipboard access | optional |
+
+Standard library only for everything else — `argparse`, `subprocess`, `webbrowser`,
+`xml.etree`, `dataclasses`, `pathlib`.
+
+---
+
+## 🚀 Installation & Usage
+
+```bash
+cd Voice_CLI_Virtual_Assistant
+pip install -r requirements.txt
+```
+
+> On Linux, `SpeechRecognition` also needs PyAudio (`sudo apt install python3-pyaudio portaudio19-dev`)
+> and clipboard reads need `xclip`. Skip both if you only want the CLI mode.
+
+```bash
+python main.py                      # interactive text session
+python main.py --voice              # interactive voice session (needs a microphone)
+python main.py --say "weather"      # one-shot command, handy in scripts
+python main.py --list-commands      # print the full command surface
+python main.py --no-tts             # text only, no spoken output
+python main.py --city Bengaluru     # override the default weather city
+python main.py --allow-power        # enable guarded shutdown/restart/logout
+```
+
+### Configuration
+
+Every setting has a default; all are overridable through the environment.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ASSISTANT_CITY` | `Jamshedpur` | default city for weather |
+| `ASSISTANT_WAKE_WORD` | `capsule` | optional wake word |
+| `ASSISTANT_SCREENSHOT_DIR` | `~/Pictures` | where screenshots are written |
+| `ASSISTANT_HEADLINES` | `5` | number of headlines to read |
+| `ASSISTANT_NEWS_EDITION` | `IN` | Google News / NewsAPI edition |
+| `ASSISTANT_TIMEOUT` | `10` | HTTP timeout in seconds |
+| `ASSISTANT_ALLOW_POWER` | `0` | enable power commands |
+| `OPENWEATHER_API_KEY` | *(unset)* | upgrade weather to OpenWeatherMap |
+| `NEWSAPI_KEY` | *(unset)* | upgrade news to NewsAPI |
+
+---
+
+## 💬 Command surface
+
+| Say / type | Intent | What happens |
+|------------|--------|--------------|
+| `hello`, `hi`, `namaste` | greet | time-aware greeting |
+| `what is the time` | time | current clock time |
+| `todays date` | date | today's date |
+| `weather`, `weather in <city>` | weather | live weather report |
+| `news`, `headlines` | news | top headlines of the day |
+| `battery` | battery | charge %, state, runtime left |
+| `screenshot` | screenshot | timestamped desktop capture |
+| `clipboard` | clipboard | reads the copied text back |
+| `system info` | system | host OS summary |
+| `who is <topic>`, `tell me about <topic>` | wikipedia | Wikipedia summary |
+| `google <query>` | google | opens Google results |
+| `play <query>` | youtube | opens YouTube results |
+| `play file <path>` | open_media | plays a local file |
+| `shutdown`, `restart`, `log out` | power | guarded power controls |
+| `help` | help | lists every command |
+| `exit`, `quit`, `bye` | exit | ends the session |
+
+---
+
+## 📁 Project structure
+
+```
+Voice_CLI_Virtual_Assistant/
+├── main.py                          # launcher
+├── requirements.txt
+├── assistant/
+│   ├── __init__.py
+│   ├── config.py                    # env-driven settings
+│   ├── speech.py                    # TTS + STT with fallbacks
+│   ├── knowledge.py                 # Wikipedia / Google / YouTube
+│   ├── live_data.py                 # weather + news providers and parsers
+│   ├── system_tools.py              # clipboard, screenshot, battery, media, power
+│   ├── commands.py                  # intent router
+│   ├── core.py                      # VirtualAssistant orchestration
+│   └── cli.py                       # argument parsing and loops
+├── tests/
+│   └── test_assistant.py            # 43 offline unit tests
+├── assets/
+│   └── demo_session.txt             # recorded terminal session
+└── voice_cli_assistant_demo.ipynb   # annotated walkthrough notebook
+```
+
+---
+
+## 🧪 Tests
+
+```bash
+python -m unittest discover -s tests -v     # or: python -m pytest tests -q
+```
+
+```text
+Ran 43 tests in 0.007s
+
+OK
+```
+
+No microphone, browser or network access is required — the suite injects test doubles for
+the browser opener, the power-command runner and the speech engine, and feeds the parsers
+recorded payloads.
+
+---
+
+## 📸 Demo
+
+Full recorded session: [`assets/demo_session.txt`](assets/demo_session.txt)
+(live weather, live news and a real Wikipedia lookup included).
+
+```text
+$ python main.py --no-tts
+assistant > Good morning! I am your ML-CaPsule assistant, listening in text mode. Say 'help' to see what I can do.
+you > hello
+assistant > Good morning! How can I help you?
+you > battery
+assistant > The battery is at 76 percent and on battery. About 7 hours and 41 minutes remaining.
+you > what is the time
+assistant > The time is 1:16 AM.
+you > exit
+assistant > Goodbye! Shutting down the assistant.
+```
+
+```text
+$ python main.py --no-tts --say "weather"
+assistant > Mist in Jamshedpur. It is 26 degrees Celsius and feels like 30, with 95% humidity and 4 kilometres per hour of wind.
+
+$ python main.py --no-tts --say "news"
+assistant > Here are the top 5 headlines.
+1. 'Want To Forgive Them': PM Modi On Students Who Abused Him at Jantar Mantar - NDTV
+2. Spain deploys military to Ceuta after migrant surge: What we know - Al Jazeera
+...
+
+$ python main.py --no-tts --say "who is Alan Turing"
+assistant > According to Wikipedia: Alan Mathison Turing was an English mathematician, computer
+scientist, logician, cryptanalyst, philosopher and theoretical biologist. ...
+
+$ python main.py --no-tts --say "make me a sandwich"
+assistant > I did not understand that. Say 'help' to see what I can do.
+```
+
+The graceful-degradation path, captured on a host without `pyautogui` and without Screen
+Recording permission:
+
+```text
+$ python main.py --no-tts --say "take a screenshot"
+assistant > Screen capture is unavailable. Install pyautogui, and on macOS grant your
+            terminal Screen Recording permission in System Settings > Privacy & Security.
+```
+
+---
+
+## 🔭 Future improvements
+
+- Offline wake-word detection (Porcupine / Vosk) so voice mode needs no cloud STT.
+- Intent classification with a small trained model instead of regex, to handle paraphrases.
+- Alarms, reminders and a calendar integration.
+- A plugin interface so new intents can be dropped in without touching the router.
+
+---
+
+## 👤 Author
+
+Contributed to **ML-CaPsule** under **GSSoC** by [Anijesh](https://github.com/Anijesh) — resolves issue #1984.

--- a/Voice_CLI_Virtual_Assistant/assets/demo_session.txt
+++ b/Voice_CLI_Virtual_Assistant/assets/demo_session.txt
@@ -1,0 +1,103 @@
+=== Voice & CLI Virtual Assistant - recorded demo session ===
+Host: macOS (Darwin 25.5.0, arm64) | Python 3.14
+Installed extras: requests, psutil, wikipedia, pyperclip, pyttsx3, SpeechRecognition
+Not installed: pyautogui (screenshot falls back to the native macOS utility)
+
+--- 1. One-shot commands --------------------------------------------
+
+$ python main.py --no-tts --say "hello"
+assistant > Good morning! How can I help you?
+
+$ python main.py --no-tts --say "what is the time"
+assistant > The time is 1:16 AM.
+
+$ python main.py --no-tts --say "todays date"
+assistant > Today is Saturday, 1 August 2026.
+
+$ python main.py --no-tts --say "system info"
+assistant > Darwin 25.5.0 on arm64, running Python 3.14.
+
+$ python main.py --no-tts --say "battery"
+assistant > The battery is at 76 percent and on battery. About 7 hours and 41 minutes remaining.
+
+$ python main.py --no-tts --say "weather"
+assistant > Mist in Jamshedpur. It is 26 degrees Celsius and feels like 30, with 95% humidity and 4 kilometres per hour of wind.
+
+$ python main.py --no-tts --say "weather in mumbai today"
+assistant > Mist in Mumbai. It is 28 degrees Celsius and feels like 32, with 89% humidity and 35 kilometres per hour of wind.
+
+$ python main.py --no-tts --say "news"
+assistant > Here are the top 5 headlines.
+1. 'Want To Forgive Them': PM Modi On Students Who Abused Him at Jantar Mantar - NDTV
+2. Spain deploys military to Ceuta after migrant surge: What we know - Al Jazeera
+3. 'Pak-trained Mujahideen have turned their guns inwards': India slams Islamabad over PoK crackdown - The Times of India
+4. Breaking | Tahir Hussain, Others Get Life Imprisonment For Murder Of IB Staffer Ankit Sharma During Delhi ... - livelaw.in
+5. At least one non-local labourer killed, another injured in terrorist shooting in J&K’s Kulgam - The Hindu
+
+$ python main.py --no-tts --say "who is Alan Turing"
+assistant > According to Wikipedia: Alan Mathison Turing was an English mathematician, computer scientist, logician, cryptanalyst, philosopher and theoretical biologist. He was highly influential in the development of theoretical computer science, providing a formalisation of the concepts of algorithm and computation with the Turing machine, which can be considered a model of a general-purpose computer.
+
+$ python main.py --no-tts --say "clipboard"
+assistant > The clipboard says: https://github.com/Niketkumardheeryan/ML-CaPsule/issues/1984
+
+$ python main.py --no-tts --say "take a screenshot"
+assistant > Screen capture is unavailable. Install pyautogui, and on macOS grant your terminal Screen Recording permission in System Settings > Privacy & Security.
+
+$ python main.py --no-tts --say "play file /nope/missing.mp3"
+assistant > I could not find any file at /nope/missing.mp3.
+
+$ python main.py --no-tts --say "shutdown"
+assistant > Power commands are disabled. Restart me with --allow-power to enable 'shutdown' (it would run: osascript -e tell app "System Events" to shut down).
+
+$ python main.py --no-tts --say "make me a sandwich"
+assistant > I did not understand that. Say 'help' to see what I can do.
+
+--- 2. Interactive session (typed input, 'exit' quits) --------------
+
+$ python main.py --no-tts
+assistant > Good morning! I am your ML-CaPsule assistant, listening in text mode. Say 'help' to see what I can do.
+you > hello
+assistant > Good morning! How can I help you?
+you > battery
+assistant > The battery is at 76 percent and on battery. About 7 hours and 41 minutes remaining.
+you > what is the time
+assistant > The time is 1:16 AM.
+you > exit
+assistant > Goodbye! Shutting down the assistant.
+
+--- 3. Full command surface -----------------------------------------
+
+$ python main.py --list-commands
+Here is what I can do:
+  - exit / quit / bye - close the assistant
+  - help - list every supported command
+  - hello - time aware greeting
+  - what is the time - current clock time
+  - what is the date - today's date
+  - weather [in <city>] - live weather report
+  - news - top headlines of the day
+  - battery - charge percentage and time left
+  - screenshot - timestamped desktop capture
+  - clipboard - read back the copied text
+  - system info - host operating system summary
+  - play file <path> - open media in the default player
+  - shutdown / restart / logout - guarded power controls
+  - play <query> - stream the top YouTube result
+  - who is <topic> - Wikipedia summary
+  - google <query> - open Google results
+
+--- 4. Power-control safety gates -----------------------------------
+
+$ python main.py --no-tts --say "restart"            # gate 1: disabled by default
+assistant > Power commands are disabled. Restart me with --allow-power to enable 'restart' (it would run: osascript -e tell app "System Events" to restart).
+
+$ python main.py --no-tts --allow-power --say "restart"   # gate 2: confirmation declined
+Type 'restart' to confirm, anything else cancels: assistant > Cancelled the restart request.
+
+--- 5. Test suite ----------------------------------------------------
+
+$ python -m unittest discover -s tests
+----------------------------------------------------------------------
+Ran 43 tests in 0.004s
+
+OK

--- a/Voice_CLI_Virtual_Assistant/assistant/__init__.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/__init__.py
@@ -1,0 +1,20 @@
+"""Voice & CLI driven system virtual assistant.
+
+The package is intentionally split into small, independently testable modules:
+
+``config``        runtime settings resolved from environment variables
+``speech``        text-to-speech and speech-to-text with graceful fallbacks
+``knowledge``     Wikipedia / Google / YouTube lookups
+``live_data``     weather and news headlines from keyless public endpoints
+``system_tools``  clipboard, screenshots, battery telemetry, power controls
+``commands``      regex based intent router
+``core``          the assistant object that wires everything together
+``cli``           argument parsing and the interactive loops
+"""
+
+from .config import AssistantConfig, load_config
+from .core import VirtualAssistant
+
+__all__ = ["AssistantConfig", "load_config", "VirtualAssistant", "__version__"]
+
+__version__ = "1.0.0"

--- a/Voice_CLI_Virtual_Assistant/assistant/cli.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/cli.py
@@ -1,0 +1,75 @@
+"""Command line entry point.
+
+Examples
+--------
+    python main.py                      # interactive text session
+    python main.py --voice              # interactive voice session
+    python main.py --say "weather"      # one-shot command, useful in scripts
+    python main.py --list-commands      # print the supported command surface
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .config import load_config
+from .core import VirtualAssistant
+from .speech import SpeechEngine
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the argument parser for the assistant."""
+    parser = argparse.ArgumentParser(
+        prog="virtual-assistant",
+        description="Voice and CLI driven system virtual assistant.",
+    )
+    parser.add_argument("--voice", action="store_true",
+                        help="listen on the microphone instead of the keyboard")
+    parser.add_argument("--say", metavar="COMMAND",
+                        help="run a single command and exit")
+    parser.add_argument("--city", metavar="CITY",
+                        help="override the default city used for weather")
+    parser.add_argument("--no-tts", action="store_true",
+                        help="disable spoken output and print responses only")
+    parser.add_argument("--allow-power", action="store_true",
+                        help="enable shutdown/restart/logout (still asks for confirmation)")
+    parser.add_argument("--list-commands", action="store_true",
+                        help="print every supported command and exit")
+    return parser
+
+
+def build_assistant(args) -> VirtualAssistant:
+    """Create a :class:`VirtualAssistant` configured from parsed ``args``."""
+    config = load_config()
+    if args.city:
+        config.city = args.city
+    if args.allow_power:
+        config.allow_power_commands = True
+
+    speech = SpeechEngine(
+        config,
+        enable_tts=not args.no_tts,
+        enable_stt=bool(args.voice),
+    )
+    return VirtualAssistant(config=config, speech=speech)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the assistant and return a process exit code."""
+    args = build_parser().parse_args(argv)
+    assistant = build_assistant(args)
+
+    if args.list_commands:
+        print(assistant.router.help_text())
+        return 0
+
+    if args.say:
+        response = assistant.respond(args.say)
+        return 0 if response.handled else 1
+
+    return assistant.run(voice=bool(args.voice))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/Voice_CLI_Virtual_Assistant/assistant/commands.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/commands.py
@@ -1,0 +1,268 @@
+"""Intent router.
+
+An utterance (typed or transcribed) is normalised, matched against an ordered
+list of regular expressions and dispatched to a handler. Keeping the router
+separate from the I/O layers means the whole command surface can be unit tested
+without a microphone, a browser or a network connection.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable
+
+from . import knowledge, live_data, system_tools
+from .speech import greeting_for, spoken_date, spoken_time
+
+_PUNCTUATION = re.compile(r"[^\w\s:/\\.\-']")
+_WHITESPACE = re.compile(r"\s+")
+
+
+@dataclass
+class Response:
+    """What the assistant says back, plus loop control flags."""
+
+    text: str
+    handled: bool = True
+    should_exit: bool = False
+
+
+@dataclass
+class Intent:
+    """A named command with the patterns that trigger it."""
+
+    name: str
+    patterns: tuple[str, ...]
+    handler: Callable[..., Response]
+    help: str = ""
+    compiled: tuple[re.Pattern, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.compiled = tuple(re.compile(p, re.IGNORECASE) for p in self.patterns)
+
+    def match(self, text: str) -> re.Match | None:
+        """Return the first pattern match for ``text``, if any."""
+        for pattern in self.compiled:
+            found = pattern.search(text)
+            if found:
+                return found
+        return None
+
+
+def normalise(text: str, wake_word: str = "") -> str:
+    """Lower-case, strip punctuation and drop a leading wake word."""
+    cleaned = _PUNCTUATION.sub(" ", (text or "").lower())
+    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    if wake_word:
+        cleaned = re.sub(rf"^(?:hey\s+|ok\s+)?{re.escape(wake_word.lower())}\b[\s,]*",
+                         "", cleaned).strip()
+    return cleaned
+
+
+# --------------------------------------------------------------- handlers
+def handle_greet(assistant, match) -> Response:
+    return Response(f"{greeting_for()}! How can I help you?")
+
+
+def handle_time(assistant, match) -> Response:
+    return Response(f"The time is {spoken_time()}.")
+
+
+def handle_date(assistant, match) -> Response:
+    return Response(f"Today is {spoken_date()}.")
+
+
+def handle_wikipedia(assistant, match) -> Response:
+    topic = (match.group("topic") or "").strip()
+    if not topic:
+        return Response("What should I look up on Wikipedia?")
+    summary = knowledge.search_wikipedia(
+        topic,
+        sentences=assistant.config.wikipedia_sentences,
+        timeout=assistant.config.request_timeout,
+    )
+    return Response(f"According to Wikipedia: {summary}")
+
+
+def handle_google(assistant, match) -> Response:
+    query = (match.group("query") or "").strip()
+    if not query:
+        return Response("What should I search for?")
+    url = knowledge.search_google(query, opener=assistant.opener)
+    return Response(f"Searching Google for {query}. Opened {url}")
+
+
+def handle_youtube(assistant, match) -> Response:
+    query = (match.group("query") or "").strip()
+    if not query:
+        return Response("Which video should I play?")
+    url = knowledge.play_on_youtube(query, opener=assistant.opener)
+    return Response(f"Opening YouTube results for {query}. Opened {url}")
+
+
+TRAILING_FILLER = {"today", "now", "please", "tomorrow", "currently", "right", "there"}
+
+
+def clean_city(raw: str) -> str:
+    """Tidy a city captured from normalised (lower-cased) speech."""
+    words = [word for word in raw.split() if word]
+    while words and words[-1] in TRAILING_FILLER:
+        words.pop()
+    return " ".join(words).title()
+
+
+def handle_weather(assistant, match) -> Response:
+    city = clean_city(match.groupdict().get("city") or "") or assistant.config.city
+    return Response(live_data.fetch_weather(city, assistant.config))
+
+
+def handle_news(assistant, match) -> Response:
+    headlines = live_data.fetch_headlines(assistant.config)
+    return Response(live_data.format_headlines(headlines))
+
+
+def handle_clipboard(assistant, match) -> Response:
+    return Response(f"The clipboard says: {system_tools.read_clipboard()}")
+
+
+def handle_screenshot(assistant, match) -> Response:
+    _, message = system_tools.capture_screenshot(assistant.config)
+    return Response(message)
+
+
+def handle_battery(assistant, match) -> Response:
+    status = system_tools.battery_status()
+    if status is None:
+        return Response("No battery was detected on this machine.")
+    return Response(status.describe())
+
+
+def handle_open_media(assistant, match) -> Response:
+    path = (match.group("path") or "").strip()
+    if not path:
+        return Response("Tell me the path of the file you want to play.")
+    _, message = system_tools.open_media(path)
+    return Response(message)
+
+
+def handle_system_info(assistant, match) -> Response:
+    return Response(system_tools.system_summary())
+
+
+def handle_power(assistant, match) -> Response:
+    raw = match.group("action").lower().replace(" ", "")
+    action = {
+        "shutdown": "shutdown",
+        "poweroff": "shutdown",
+        "restart": "restart",
+        "reboot": "restart",
+        "logout": "logout",
+        "signout": "logout",
+        "logoff": "logout",
+    }.get(raw, raw)
+    _, message = system_tools.run_power_command(
+        action, assistant.config, confirm=assistant.confirm
+    )
+    return Response(message)
+
+
+def handle_help(assistant, match) -> Response:
+    return Response(assistant.router.help_text())
+
+
+def handle_exit(assistant, match) -> Response:
+    return Response("Goodbye! Shutting down the assistant.", should_exit=True)
+
+
+# ----------------------------------------------------------------- router
+def default_intents() -> list[Intent]:
+    """Return the built-in intents in priority order.
+
+    Order matters: narrow patterns such as ``what is the time`` must be tried
+    before the catch-all ``what is <topic>`` Wikipedia lookup.
+    """
+    return [
+        Intent("exit", (r"^(?:exit|quit|stop|bye|goodbye|shut up)$",),
+               handle_exit, "exit / quit / bye - close the assistant"),
+        Intent("help", (r"^(?:help|commands|what can you do)\b",),
+               handle_help, "help - list every supported command"),
+        Intent("greet", (r"^(?:hello|hi|hey|namaste|good (?:morning|afternoon|evening))\b",),
+               handle_greet, "hello - time aware greeting"),
+        Intent("time", (r"\b(?:what(?:'s| is) the )?time\b(?! in)", r"^time$"),
+               handle_time, "what is the time - current clock time"),
+        Intent("date",
+               (r"\b(?:today'?s date|what(?:'s| is) the date|which day is it)\b", r"^date$"),
+               handle_date, "what is the date - today's date"),
+        Intent("weather",
+               (r"\b(?:weather|temperature|forecast)\b(?:\s+(?:in|at|for)\s+(?P<city>[\w\s]+))?",),
+               handle_weather, "weather [in <city>] - live weather report"),
+        Intent("news", (r"\b(?:news|headlines|top stories)\b",),
+               handle_news, "news - top headlines of the day"),
+        Intent("battery", (r"\b(?:battery|charge level|power level)\b",),
+               handle_battery, "battery - charge percentage and time left"),
+        Intent("screenshot", (r"\b(?:screenshot|screen shot|capture (?:the )?screen)\b",),
+               handle_screenshot, "screenshot - timestamped desktop capture"),
+        Intent("clipboard", (r"\b(?:clipboard|copied text|read clip)\b",),
+               handle_clipboard, "clipboard - read back the copied text"),
+        Intent("system", (r"\b(?:system info|system information|about this (?:pc|mac|system))\b",),
+               handle_system_info, "system info - host operating system summary"),
+        Intent("open_media", (r"^(?:play|open)\s+(?:file|media|song file)\s+(?P<path>.+)$",),
+               handle_open_media, "play file <path> - open media in the default player"),
+        Intent("power",
+               (r"^(?P<action>shut ?down|power ?off|restart|reboot"
+                r"|log ?out|sign ?out|log ?off)\b",),
+               handle_power, "shutdown / restart / logout - guarded power controls"),
+        Intent("youtube", (r"^(?:play|youtube|open youtube)\s+(?P<query>.+)$",),
+               handle_youtube, "play <query> - stream the top YouTube result"),
+        Intent("wikipedia",
+               (r"^(?:wikipedia|search wikipedia for|look up)\s+(?P<topic>.+)$",
+                r"^(?:who|what)(?:'s| is|are|was|were)\s+(?P<topic>.+)$",
+                r"^tell me about\s+(?P<topic>.+)$"),
+               handle_wikipedia, "who is <topic> - Wikipedia summary"),
+        Intent("google", (r"^(?:google|search(?: for)?)\s+(?P<query>.+)$",),
+               handle_google, "google <query> - open Google results"),
+    ]
+
+
+class CommandRouter:
+    """Matches normalised text against intents and dispatches handlers."""
+
+    def __init__(self, intents: list[Intent] | None = None) -> None:
+        self.intents = intents if intents is not None else default_intents()
+
+    def match(self, text: str) -> tuple[Intent, re.Match] | None:
+        """Return the first matching ``(intent, match)`` pair, if any."""
+        for intent in self.intents:
+            found = intent.match(text)
+            if found:
+                return intent, found
+        return None
+
+    def dispatch(self, assistant, text: str) -> Response:
+        """Route ``text`` to a handler and return its :class:`Response`."""
+        if not text.strip():
+            return Response("", handled=False)
+        result = self.match(text)
+        if result is None:
+            return Response(
+                "I did not understand that. Say 'help' to see what I can do.",
+                handled=False,
+            )
+        intent, found = result
+        return intent.handler(assistant, found)
+
+    def help_text(self) -> str:
+        """Return a readable list of every supported command."""
+        lines = ["Here is what I can do:"]
+        lines += [f"  - {intent.help}" for intent in self.intents if intent.help]
+        return "\n".join(lines)
+
+
+__all__ = [
+    "CommandRouter",
+    "Intent",
+    "Response",
+    "default_intents",
+    "normalise",
+]

--- a/Voice_CLI_Virtual_Assistant/assistant/config.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/config.py
@@ -1,0 +1,89 @@
+"""Runtime configuration for the virtual assistant.
+
+Every setting has a sensible default so the assistant runs out of the box with
+no configuration at all. API keys are optional: when they are absent the
+assistant falls back to keyless public endpoints (see :mod:`assistant.live_data`).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_CITY = "Jamshedpur"
+DEFAULT_WAKE_WORD = "capsule"
+DEFAULT_TIMEOUT = 10.0
+DEFAULT_HEADLINES = 5
+
+
+def _env_str(name: str, default: str) -> str:
+    value = os.environ.get(name, "").strip()
+    return value or default
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer environment variable, ignoring malformed values."""
+    raw = os.environ.get(name, "").strip()
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class AssistantConfig:
+    """Settings that control assistant behaviour."""
+
+    city: str = DEFAULT_CITY
+    wake_word: str = DEFAULT_WAKE_WORD
+    screenshot_dir: Path = field(default_factory=lambda: Path.home() / "Pictures")
+    request_timeout: float = DEFAULT_TIMEOUT
+    max_headlines: int = DEFAULT_HEADLINES
+    news_edition: str = "IN"
+    speech_rate: int = 175
+    speech_volume: float = 1.0
+    wikipedia_sentences: int = 2
+    openweather_api_key: str = ""
+    newsapi_key: str = ""
+    # Power commands (shutdown / restart / logout) are irreversible, so they stay
+    # disabled unless the user opts in explicitly *and* confirms interactively.
+    allow_power_commands: bool = False
+
+    def screenshot_target(self, filename: str) -> Path:
+        """Return the absolute path a screenshot should be written to."""
+        return self.screenshot_dir.expanduser() / filename
+
+
+def load_config() -> AssistantConfig:
+    """Build an :class:`AssistantConfig` from the process environment."""
+    screenshot_dir = _env_str("ASSISTANT_SCREENSHOT_DIR", "")
+    return AssistantConfig(
+        city=_env_str("ASSISTANT_CITY", DEFAULT_CITY),
+        wake_word=_env_str("ASSISTANT_WAKE_WORD", DEFAULT_WAKE_WORD).lower(),
+        screenshot_dir=Path(screenshot_dir) if screenshot_dir else Path.home() / "Pictures",
+        request_timeout=_env_float("ASSISTANT_TIMEOUT", DEFAULT_TIMEOUT),
+        max_headlines=_env_int("ASSISTANT_HEADLINES", DEFAULT_HEADLINES),
+        news_edition=_env_str("ASSISTANT_NEWS_EDITION", "IN"),
+        speech_rate=_env_int("ASSISTANT_SPEECH_RATE", 175),
+        speech_volume=_env_float("ASSISTANT_SPEECH_VOLUME", 1.0),
+        wikipedia_sentences=_env_int("ASSISTANT_WIKI_SENTENCES", 2),
+        openweather_api_key=_env_str("OPENWEATHER_API_KEY", ""),
+        newsapi_key=_env_str("NEWSAPI_KEY", ""),
+        allow_power_commands=_env_flag("ASSISTANT_ALLOW_POWER", False),
+    )

--- a/Voice_CLI_Virtual_Assistant/assistant/core.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/core.py
@@ -1,0 +1,70 @@
+"""The assistant object that wires configuration, speech and the router."""
+
+from __future__ import annotations
+
+import webbrowser
+
+from .commands import CommandRouter, normalise
+from .config import AssistantConfig, load_config
+from .speech import SpeechEngine, greeting_for
+
+
+class VirtualAssistant:
+    """Multi-modal assistant driven by either typed or spoken commands."""
+
+    def __init__(self, config: AssistantConfig | None = None,
+                 speech: SpeechEngine | None = None,
+                 router: CommandRouter | None = None,
+                 opener=None, confirm=None) -> None:
+        self.config = config or load_config()
+        self.speech = speech or SpeechEngine(self.config)
+        self.router = router or CommandRouter()
+        # Injected so tests never open a browser and never touch power state.
+        self.opener = opener or webbrowser.open
+        self.confirm = confirm or self._confirm_interactively
+
+    # ------------------------------------------------------------- helpers
+    def _confirm_interactively(self, action: str) -> bool:
+        """Ask the user to type the action name before a power command runs."""
+        prompt = f"Type '{action}' to confirm, anything else cancels: "
+        try:
+            return input(prompt).strip().lower() == action
+        except (EOFError, KeyboardInterrupt):
+            return False
+
+    def greeting(self) -> str:
+        """Return the start-up greeting."""
+        modes = "voice and text" if self.speech.stt_available else "text"
+        return (
+            f"{greeting_for()}! I am your ML-CaPsule assistant, listening in "
+            f"{modes} mode. Say 'help' to see what I can do."
+        )
+
+    # -------------------------------------------------------------- driver
+    def handle(self, utterance: str):
+        """Normalise ``utterance``, dispatch it and return the response."""
+        return self.router.dispatch(self, normalise(utterance, self.config.wake_word))
+
+    def respond(self, utterance: str):
+        """Handle ``utterance`` and speak the response aloud."""
+        response = self.handle(utterance)
+        if response.text:
+            self.speech.speak(response.text)
+        return response
+
+    def run(self, voice: bool = False) -> int:
+        """Run the interactive loop until the user exits."""
+        self.speech.enable_stt = voice
+        self.speech.speak(self.greeting())
+        while True:
+            try:
+                utterance = self.speech.listen("you > ")
+            except KeyboardInterrupt:
+                print()
+                self.speech.speak("Goodbye!")
+                return 0
+            if not utterance.strip():
+                continue
+            response = self.respond(utterance)
+            if response.should_exit:
+                return 0

--- a/Voice_CLI_Virtual_Assistant/assistant/knowledge.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/knowledge.py
@@ -1,0 +1,110 @@
+"""Web and knowledge integrations: Wikipedia, Google search, YouTube.
+
+URL builders are pure functions so they can be unit tested without touching the
+network or opening a browser window.
+"""
+
+from __future__ import annotations
+
+import re
+import webbrowser
+from urllib.parse import quote, quote_plus
+
+GOOGLE_SEARCH = "https://www.google.com/search?q={}"
+YOUTUBE_SEARCH = "https://www.youtube.com/results?search_query={}"
+WIKIPEDIA_SUMMARY = "https://en.wikipedia.org/api/rest_v1/page/summary/{}"
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+def google_search_url(query: str) -> str:
+    """Build the Google results URL for ``query``."""
+    return GOOGLE_SEARCH.format(quote_plus(query.strip()))
+
+
+def youtube_search_url(query: str) -> str:
+    """Build the YouTube results URL for ``query``."""
+    return YOUTUBE_SEARCH.format(quote_plus(query.strip()))
+
+
+def trim_sentences(text: str, limit: int) -> str:
+    """Return at most ``limit`` sentences from ``text``."""
+    if limit <= 0 or not text:
+        return text.strip()
+    sentences = _SENTENCE_SPLIT.split(text.strip())
+    return " ".join(sentences[:limit]).strip()
+
+
+def open_in_browser(url: str, opener=None) -> str:
+    """Open ``url`` with the default browser and return the URL that was used."""
+    (opener or webbrowser.open)(url)
+    return url
+
+
+def search_google(query: str, opener=None) -> str:
+    """Launch a Google search for ``query`` in the default browser."""
+    return open_in_browser(google_search_url(query), opener=opener)
+
+
+def play_on_youtube(query: str, opener=None) -> str:
+    """Open YouTube results for ``query`` so the first hit can be streamed."""
+    return open_in_browser(youtube_search_url(query), opener=opener)
+
+
+def _summarise_with_library(query: str, sentences: int) -> str | None:
+    """Summarise using the ``wikipedia`` package when it is installed."""
+    try:
+        import wikipedia
+    except ImportError:
+        return None
+
+    try:
+        return wikipedia.summary(query, sentences=sentences, auto_suggest=True)
+    except Exception as exc:  # DisambiguationError, PageError, network errors
+        options = getattr(exc, "options", None)
+        if options:
+            return (
+                f"'{query}' matches several Wikipedia pages, for example: "
+                + ", ".join(list(options)[:3])
+                + ". Please be more specific."
+            )
+        return None
+
+
+def _summarise_with_rest_api(query: str, sentences: int, timeout: float) -> str | None:
+    """Keyless fallback that queries the public Wikipedia REST endpoint."""
+    try:
+        import requests
+
+        response = requests.get(
+            WIKIPEDIA_SUMMARY.format(quote(query.strip().replace(" ", "_"))),
+            timeout=timeout,
+            headers={"User-Agent": "ML-CaPsule-Virtual-Assistant/1.0"},
+        )
+        if response.status_code != 200:
+            return None
+        extract = response.json().get("extract", "")
+        return trim_sentences(extract, sentences) or None
+    except Exception:  # offline, DNS failure, malformed payload
+        return None
+
+
+def search_wikipedia(query: str, sentences: int = 2, timeout: float = 10.0) -> str:
+    """Return a short Wikipedia summary for ``query``.
+
+    The ``wikipedia`` package is preferred; if it is not installed or fails, the
+    keyless REST API is used before giving up with a readable message.
+    """
+    query = query.strip()
+    if not query:
+        return "Please tell me what you would like me to look up on Wikipedia."
+
+    summary = _summarise_with_library(query, sentences)
+    if summary:
+        return trim_sentences(summary, sentences)
+
+    summary = _summarise_with_rest_api(query, sentences, timeout)
+    if summary:
+        return summary
+
+    return f"I could not find a Wikipedia article for '{query}'."

--- a/Voice_CLI_Virtual_Assistant/assistant/live_data.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/live_data.py
@@ -1,0 +1,194 @@
+"""Live data orchestration: localised weather and top news headlines.
+
+Both providers work without an API key:
+
+* weather  -> ``wttr.in`` JSON (OpenWeatherMap is used when a key is exported)
+* headlines -> Google News RSS (NewsAPI is used when a key is exported)
+
+Network access is confined to the ``fetch_*`` helpers; the payload parsers are
+pure functions and therefore unit tested offline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import quote
+from xml.etree import ElementTree
+
+WTTR_ENDPOINT = "https://wttr.in/{}?format=j1"
+OPENWEATHER_ENDPOINT = "https://api.openweathermap.org/data/2.5/weather"
+GOOGLE_NEWS_RSS = "https://news.google.com/rss?hl=en-{edition}&gl={edition}&ceid={edition}:en"
+NEWSAPI_ENDPOINT = "https://newsapi.org/v2/top-headlines"
+
+USER_AGENT = {"User-Agent": "ML-CaPsule-Virtual-Assistant/1.0"}
+
+
+@dataclass
+class WeatherReport:
+    """Normalised weather snapshot, independent of the provider used."""
+
+    city: str
+    description: str
+    temperature_c: float
+    feels_like_c: float
+    humidity: int
+    wind_kmph: float
+    source: str = "wttr.in"
+
+    def describe(self) -> str:
+        """Render the report as a single sentence suitable for speech."""
+        return (
+            f"{self.description} in {self.city}. "
+            f"It is {self.temperature_c:.0f} degrees Celsius and feels like "
+            f"{self.feels_like_c:.0f}, with {self.humidity}% humidity and "
+            f"{self.wind_kmph:.0f} kilometres per hour of wind."
+        )
+
+
+def _to_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_int(value, default: int = 0) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_wttr_payload(payload: dict, city: str) -> WeatherReport:
+    """Convert a ``wttr.in`` ``format=j1`` payload into a :class:`WeatherReport`."""
+    current = (payload.get("current_condition") or [{}])[0]
+    descriptions = current.get("weatherDesc") or [{}]
+    return WeatherReport(
+        city=city,
+        description=(descriptions[0].get("value") or "Current conditions").strip(),
+        temperature_c=_to_float(current.get("temp_C")),
+        feels_like_c=_to_float(current.get("FeelsLikeC")),
+        humidity=_to_int(current.get("humidity")),
+        wind_kmph=_to_float(current.get("windspeedKmph")),
+        source="wttr.in",
+    )
+
+
+def parse_openweather_payload(payload: dict, city: str) -> WeatherReport:
+    """Convert an OpenWeatherMap payload into a :class:`WeatherReport`."""
+    weather = (payload.get("weather") or [{}])[0]
+    main = payload.get("main") or {}
+    wind_ms = _to_float((payload.get("wind") or {}).get("speed"))
+    return WeatherReport(
+        city=payload.get("name") or city,
+        description=(weather.get("description") or "Current conditions").capitalize(),
+        temperature_c=_to_float(main.get("temp")),
+        feels_like_c=_to_float(main.get("feels_like")),
+        humidity=_to_int(main.get("humidity")),
+        wind_kmph=wind_ms * 3.6,
+        source="OpenWeatherMap",
+    )
+
+
+def parse_news_rss(xml_text: str, limit: int = 5) -> list[str]:
+    """Extract up to ``limit`` headline titles from an RSS document."""
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError:
+        return []
+
+    headlines: list[str] = []
+    for item in root.iterfind(".//item"):
+        title = (item.findtext("title") or "").strip()
+        if title:
+            headlines.append(title)
+        if len(headlines) >= limit:
+            break
+    return headlines
+
+
+def fetch_weather(city: str, config) -> str:
+    """Return a spoken weather report for ``city``."""
+    try:
+        import requests
+    except ImportError:  # pragma: no cover - requests ships with the repo deps
+        return "The requests package is required for weather lookups."
+
+    if config.openweather_api_key:
+        try:
+            response = requests.get(
+                OPENWEATHER_ENDPOINT,
+                params={
+                    "q": city,
+                    "appid": config.openweather_api_key,
+                    "units": "metric",
+                },
+                timeout=config.request_timeout,
+                headers=USER_AGENT,
+            )
+            if response.status_code == 200:
+                return parse_openweather_payload(response.json(), city).describe()
+        except Exception:
+            pass  # fall through to the keyless provider
+
+    try:
+        response = requests.get(
+            WTTR_ENDPOINT.format(quote(city.strip())),
+            timeout=config.request_timeout,
+            headers=USER_AGENT,
+        )
+        if response.status_code != 200:
+            return f"The weather service returned status {response.status_code}."
+        return parse_wttr_payload(response.json(), city).describe()
+    except Exception:
+        return f"I could not reach the weather service for {city} right now."
+
+
+def fetch_headlines(config, limit: int | None = None) -> list[str]:
+    """Return the current top news headlines."""
+    limit = limit or config.max_headlines
+    try:
+        import requests
+    except ImportError:  # pragma: no cover - requests ships with the repo deps
+        return []
+
+    if config.newsapi_key:
+        try:
+            response = requests.get(
+                NEWSAPI_ENDPOINT,
+                params={
+                    "country": config.news_edition.lower(),
+                    "pageSize": limit,
+                    "apiKey": config.newsapi_key,
+                },
+                timeout=config.request_timeout,
+                headers=USER_AGENT,
+            )
+            if response.status_code == 200:
+                articles = response.json().get("articles") or []
+                titles = [a.get("title", "").strip() for a in articles if a.get("title")]
+                if titles:
+                    return titles[:limit]
+        except Exception:
+            pass  # fall through to the keyless provider
+
+    try:
+        response = requests.get(
+            GOOGLE_NEWS_RSS.format(edition=config.news_edition.upper()),
+            timeout=config.request_timeout,
+            headers=USER_AGENT,
+        )
+        if response.status_code != 200:
+            return []
+        return parse_news_rss(response.text, limit)
+    except Exception:
+        return []
+
+
+def format_headlines(headlines: list[str]) -> str:
+    """Render headlines as a numbered, speech friendly block."""
+    if not headlines:
+        return "I could not fetch the news headlines right now."
+    lines = [f"Here are the top {len(headlines)} headlines."]
+    lines += [f"{index}. {title}" for index, title in enumerate(headlines, start=1)]
+    return "\n".join(lines)

--- a/Voice_CLI_Virtual_Assistant/assistant/speech.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/speech.py
@@ -1,0 +1,157 @@
+"""Speech layer: offline text-to-speech plus microphone speech-to-text.
+
+Both capabilities are optional. ``pyttsx3`` and ``SpeechRecognition`` are
+imported lazily so the assistant still starts on a head-less machine, inside a
+container, or on a laptop without a microphone -- it simply degrades to plain
+text output and keyboard input.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+
+MORNING_END = 12
+AFTERNOON_END = 17
+NIGHT_START = 21
+
+
+def greeting_for(moment: datetime | None = None) -> str:
+    """Return a time-of-day greeting for ``moment`` (defaults to now)."""
+    hour = (moment or datetime.now()).hour
+    if hour < MORNING_END:
+        return "Good morning"
+    if hour < AFTERNOON_END:
+        return "Good afternoon"
+    if hour < NIGHT_START:
+        return "Good evening"
+    return "Good night"
+
+
+def spoken_time(moment: datetime | None = None) -> str:
+    """Return the current clock time in a form that reads well aloud."""
+    return (moment or datetime.now()).strftime("%I:%M %p").lstrip("0")
+
+
+def spoken_date(moment: datetime | None = None) -> str:
+    """Return today's date in a form that reads well aloud."""
+    now = moment or datetime.now()
+    return f"{now.strftime('%A')}, {now.day} {now.strftime('%B %Y')}"
+
+
+class SpeechEngine:
+    """Wraps TTS/STT and always keeps a usable text fallback."""
+
+    def __init__(self, config, enable_tts: bool = True, enable_stt: bool = False,
+                 stream=None) -> None:
+        self.config = config
+        self.enable_tts = enable_tts
+        self.enable_stt = enable_stt
+        self.stream = stream or sys.stdout
+        self._tts_engine = None
+        self._tts_failed = False
+        self._recognizer = None
+        self._microphone = None
+        self._stt_failed = False
+
+    # ------------------------------------------------------------------ TTS
+    @property
+    def tts_available(self) -> bool:
+        """True when a speech synthesiser could be initialised."""
+        return self.enable_tts and not self._tts_failed and self._ensure_tts() is not None
+
+    def _ensure_tts(self):
+        if self._tts_engine is not None or self._tts_failed:
+            return self._tts_engine
+        try:
+            import pyttsx3  # imported lazily: needs a system speech driver
+
+            engine = pyttsx3.init()
+            engine.setProperty("rate", self.config.speech_rate)
+            engine.setProperty("volume", self.config.speech_volume)
+            self._tts_engine = engine
+        except Exception:  # pragma: no cover - depends on host audio stack
+            self._tts_failed = True
+            self._tts_engine = None
+        return self._tts_engine
+
+    def speak(self, text: str) -> str:
+        """Print ``text`` and, when possible, say it out loud."""
+        if not text:
+            return ""
+        print(f"assistant > {text}", file=self.stream)
+        if self.enable_tts and not self._tts_failed:
+            engine = self._ensure_tts()
+            if engine is not None:
+                try:
+                    engine.say(text)
+                    engine.runAndWait()
+                except Exception:  # pragma: no cover - host audio stack
+                    # One failure is enough: fall back to text for the session.
+                    self._tts_failed = True
+        return text
+
+    # ------------------------------------------------------------------ STT
+    @property
+    def stt_available(self) -> bool:
+        """True when a microphone and recogniser could be initialised."""
+        return self.enable_stt and not self._stt_failed and self._ensure_stt()
+
+    def _ensure_stt(self) -> bool:
+        if self._stt_failed:
+            return False
+        if self._recognizer is not None:
+            return True
+        try:
+            import speech_recognition as sr  # lazily imported: needs PyAudio
+
+            recognizer = sr.Recognizer()
+            microphone = sr.Microphone()
+            recognizer.dynamic_energy_threshold = True
+            self._recognizer = recognizer
+            self._microphone = microphone
+            return True
+        except Exception:  # pragma: no cover - depends on host audio stack
+            self._stt_failed = True
+            return False
+
+    def listen(self, prompt: str = "you > ", timeout: float = 6.0,
+               phrase_limit: float = 8.0) -> str:
+        """Return a transcribed utterance, or typed text when audio is absent."""
+        if not self.stt_available:
+            return self._read_line(prompt)
+
+        import speech_recognition as sr
+
+        try:
+            with self._microphone as source:
+                print("listening...", file=self.stream)
+                self._recognizer.adjust_for_ambient_noise(source, duration=0.4)
+                audio = self._recognizer.listen(
+                    source, timeout=timeout, phrase_time_limit=phrase_limit
+                )
+            heard = self._recognizer.recognize_google(audio)
+            print(f"you (voice) > {heard}", file=self.stream)
+            return heard
+        except sr.WaitTimeoutError:
+            return ""
+        except sr.UnknownValueError:
+            self.speak("Sorry, I did not catch that.")
+            return ""
+        except Exception:  # pragma: no cover - network or driver failure
+            self.speak("Voice input is unavailable, switching to typed input.")
+            self._stt_failed = True
+            return self._read_line(prompt)
+
+    def _read_line(self, prompt: str) -> str:
+        try:
+            line = input(prompt)
+        except EOFError:
+            return "exit"
+        except KeyboardInterrupt:
+            print(file=self.stream)
+            return "exit"
+        if not sys.stdin.isatty():
+            # Echo piped input so scripted sessions and logs stay readable.
+            print(line, file=self.stream)
+        return line

--- a/Voice_CLI_Virtual_Assistant/assistant/system_tools.py
+++ b/Voice_CLI_Virtual_Assistant/assistant/system_tools.py
@@ -1,0 +1,241 @@
+"""System automation: clipboard, screenshots, battery telemetry, power control.
+
+Every helper degrades gracefully. Optional third-party packages (``pyautogui``,
+``psutil``, ``pyperclip``) are imported inside the functions that need them, so
+importing this module never fails on a head-less machine.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+POWER_ACTIONS = ("shutdown", "restart", "logout")
+
+# Per-platform argv for each power action. Nothing here runs unless the user
+# both enables power commands and confirms the prompt.
+_POWER_COMMANDS: dict[str, dict[str, list[str]]] = {
+    "Windows": {
+        "shutdown": ["shutdown", "/s", "/t", "5"],
+        "restart": ["shutdown", "/r", "/t", "5"],
+        "logout": ["shutdown", "/l"],
+    },
+    "Darwin": {
+        "shutdown": ["osascript", "-e", 'tell app "System Events" to shut down'],
+        "restart": ["osascript", "-e", 'tell app "System Events" to restart'],
+        "logout": ["osascript", "-e", 'tell app "System Events" to log out'],
+    },
+    "Linux": {
+        "shutdown": ["systemctl", "poweroff"],
+        "restart": ["systemctl", "reboot"],
+        "logout": ["loginctl", "terminate-user", os.environ.get("USER", "")],
+    },
+}
+
+
+def _default_runner(argv: list[str]) -> None:
+    """Run ``argv`` without raising on a non-zero exit status."""
+    subprocess.run(argv, check=False)
+
+
+def current_platform() -> str:
+    """Return the platform key used by the power command table."""
+    return platform.system()
+
+
+def power_argv(action: str, system: str | None = None) -> list[str]:
+    """Return the argv for ``action`` on ``system``; empty when unsupported."""
+    table = _POWER_COMMANDS.get(system or current_platform(), {})
+    return list(table.get(action, []))
+
+
+# --------------------------------------------------------------- clipboard
+def read_clipboard() -> str:
+    """Return the current clipboard text, or an explanatory message."""
+    try:
+        import pyperclip
+
+        text = pyperclip.paste()
+        if text:
+            return text
+    except Exception:
+        pass  # fall back to the platform utility below
+
+    system = current_platform()
+    commands = {
+        "Darwin": ["pbpaste"],
+        "Linux": ["xclip", "-selection", "clipboard", "-o"],
+        "Windows": ["powershell", "-NoProfile", "-Command", "Get-Clipboard"],
+    }
+    argv = commands.get(system)
+    if argv and (shutil.which(argv[0]) or system == "Windows"):
+        try:
+            completed = subprocess.run(argv, capture_output=True, text=True, timeout=10)
+            if completed.returncode == 0 and completed.stdout.strip():
+                return completed.stdout.strip()
+        except Exception:
+            pass
+
+    return "The clipboard is empty or unreadable on this system."
+
+
+# -------------------------------------------------------------- screenshot
+def screenshot_filename(moment: datetime | None = None) -> str:
+    """Return a timestamped screenshot file name."""
+    return (moment or datetime.now()).strftime("screenshot_%Y%m%d_%H%M%S.png")
+
+
+def capture_screenshot(config, moment: datetime | None = None) -> tuple[bool, str]:
+    """Capture the desktop and return ``(success, message)``."""
+    target = config.screenshot_target(screenshot_filename(moment))
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return False, f"Could not create the screenshot folder: {exc}"
+
+    try:
+        import pyautogui
+
+        pyautogui.screenshot().save(target)
+        return True, f"Screenshot saved to {target}"
+    except Exception:
+        pass  # try a native utility before giving up
+
+    natives = {
+        "Darwin": ["screencapture", "-x", str(target)],
+        "Linux": ["gnome-screenshot", "-f", str(target)],
+    }
+    argv = natives.get(current_platform())
+    if argv and shutil.which(argv[0]):
+        try:
+            completed = subprocess.run(argv, capture_output=True, timeout=20)
+            if completed.returncode == 0 and target.exists():
+                return True, f"Screenshot saved to {target}"
+        except Exception:
+            pass
+
+    return False, (
+        "Screen capture is unavailable. Install pyautogui, and on macOS grant your "
+        "terminal Screen Recording permission in System Settings > Privacy & Security."
+    )
+
+
+# ----------------------------------------------------------------- battery
+@dataclass
+class BatteryStatus:
+    """Battery telemetry snapshot."""
+
+    percent: float
+    plugged: bool
+    seconds_left: int | None = None
+
+    def describe(self) -> str:
+        """Render the snapshot as a single spoken sentence."""
+        state = "charging" if self.plugged else "on battery"
+        sentence = f"The battery is at {self.percent:.0f} percent and {state}."
+        remaining = format_seconds_left(self.seconds_left, self.plugged)
+        return f"{sentence} {remaining}".strip()
+
+
+def format_seconds_left(seconds: int | None, plugged: bool) -> str:
+    """Describe the remaining battery runtime in hours and minutes."""
+    if plugged or seconds is None or seconds < 0:
+        return ""
+    hours, minutes = divmod(seconds // 60, 60)
+    if hours and minutes:
+        return f"About {hours} hours and {minutes} minutes remaining."
+    if hours:
+        return f"About {hours} hours remaining."
+    return f"About {minutes} minutes remaining."
+
+
+def battery_status() -> BatteryStatus | None:
+    """Return the current battery status, or ``None`` when unavailable."""
+    try:
+        import psutil
+
+        battery = psutil.sensors_battery()
+    except Exception:
+        return None
+    if battery is None:
+        return None
+
+    seconds = battery.secsleft
+    unlimited = getattr(psutil, "POWER_TIME_UNLIMITED", -2)
+    unknown = getattr(psutil, "POWER_TIME_UNKNOWN", -1)
+    if seconds in (unlimited, unknown):
+        seconds = None
+    return BatteryStatus(
+        percent=float(battery.percent),
+        plugged=bool(battery.power_plugged),
+        seconds_left=seconds,
+    )
+
+
+# ------------------------------------------------------------------- media
+def open_media(path: str, runner=None) -> tuple[bool, str]:
+    """Play ``path`` with the operating system's default media player."""
+    media = Path(path).expanduser()
+    if not media.exists():
+        return False, f"I could not find any file at {media}."
+
+    system = current_platform()
+    if system == "Windows":
+        try:
+            os.startfile(str(media))  # type: ignore[attr-defined]  # Windows only
+            return True, f"Playing {media.name}."
+        except Exception as exc:
+            return False, f"Could not play {media.name}: {exc}"
+
+    argv = ["open", str(media)] if system == "Darwin" else ["xdg-open", str(media)]
+    try:
+        (runner or subprocess.Popen)(argv)
+        return True, f"Playing {media.name}."
+    except Exception as exc:
+        return False, f"Could not play {media.name}: {exc}"
+
+
+# ------------------------------------------------------------------- power
+def run_power_command(action: str, config, confirm=None, runner=None) -> tuple[bool, str]:
+    """Run a shutdown / restart / logout command behind two safety gates.
+
+    The command only runs when power controls are enabled (``ASSISTANT_ALLOW_POWER``
+    or ``--allow-power``) *and* ``confirm`` returns ``True``. Otherwise the exact
+    command that would have run is reported instead.
+    """
+    action = action.lower().strip()
+    if action not in POWER_ACTIONS:
+        return False, f"'{action}' is not a supported power command."
+
+    argv = power_argv(action)
+    if not argv:
+        return False, f"{action.capitalize()} is not supported on {current_platform()}."
+
+    if not config.allow_power_commands:
+        return False, (
+            f"Power commands are disabled. Restart me with --allow-power to enable "
+            f"'{action}' (it would run: {' '.join(argv)})."
+        )
+
+    if confirm is not None and not confirm(action):
+        return False, f"Cancelled the {action} request."
+
+    try:
+        (runner or _default_runner)(argv)
+        return True, f"{action.capitalize()} command issued."
+    except Exception as exc:
+        return False, f"Could not issue the {action} command: {exc}"
+
+
+def system_summary() -> str:
+    """Return a short description of the host machine."""
+    return (
+        f"{platform.system()} {platform.release()} on {platform.machine()}, "
+        f"running Python {sys.version_info.major}.{sys.version_info.minor}."
+    )

--- a/Voice_CLI_Virtual_Assistant/main.py
+++ b/Voice_CLI_Virtual_Assistant/main.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Launcher for the Voice & CLI driven system virtual assistant.
+
+    python main.py                  interactive text session
+    python main.py --voice          interactive voice session
+    python main.py --say "battery"  single command, then exit
+"""
+
+from __future__ import annotations
+
+import sys
+
+from assistant.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Voice_CLI_Virtual_Assistant/requirements.txt
+++ b/Voice_CLI_Virtual_Assistant/requirements.txt
@@ -1,0 +1,12 @@
+# Core dependency - used for weather, news and the Wikipedia REST fallback.
+requests>=2.28.0
+
+# Optional dependencies. The assistant detects each one at runtime and falls
+# back to a text-only or platform-native path when it is missing, so it starts
+# and runs even if none of these are installed.
+pyttsx3>=2.90            # offline text-to-speech synthesis
+SpeechRecognition>=3.10  # microphone speech-to-text (also needs PyAudio)
+wikipedia>=1.4.0         # Wikipedia summaries
+psutil>=5.9.0            # battery telemetry
+pyautogui>=0.9.54        # desktop screenshots
+pyperclip>=1.8.2         # clipboard access

--- a/Voice_CLI_Virtual_Assistant/tests/test_assistant.py
+++ b/Voice_CLI_Virtual_Assistant/tests/test_assistant.py
@@ -1,0 +1,367 @@
+"""Unit tests for the virtual assistant.
+
+The suite runs completely offline: no microphone, no browser and no network
+call is made. Run it with either of:
+
+    python -m unittest discover -s tests -v
+    python -m pytest tests -q
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assistant import commands, knowledge, live_data, system_tools  # noqa: E402
+from assistant.config import AssistantConfig, load_config  # noqa: E402
+from assistant.core import VirtualAssistant  # noqa: E402
+from assistant.speech import greeting_for, spoken_date, spoken_time  # noqa: E402
+
+
+class RecordingSpeech:
+    """Speech double that records what would have been spoken."""
+
+    def __init__(self) -> None:
+        self.spoken: list[str] = []
+        self.enable_stt = False
+        self.stt_available = False
+
+    def speak(self, text: str) -> str:
+        self.spoken.append(text)
+        return text
+
+
+def build_assistant(**overrides) -> tuple[VirtualAssistant, list[str], RecordingSpeech]:
+    """Return an assistant wired to test doubles instead of real I/O."""
+    opened: list[str] = []
+    speech = RecordingSpeech()
+    config = AssistantConfig(city="Jamshedpur", wake_word="capsule", **overrides)
+    assistant = VirtualAssistant(
+        config=config,
+        speech=speech,
+        opener=opened.append,
+        confirm=lambda action: False,
+    )
+    return assistant, opened, speech
+
+
+class GreetingTests(unittest.TestCase):
+    def test_greeting_changes_with_time_of_day(self):
+        self.assertEqual(greeting_for(datetime(2026, 8, 1, 8, 0)), "Good morning")
+        self.assertEqual(greeting_for(datetime(2026, 8, 1, 13, 0)), "Good afternoon")
+        self.assertEqual(greeting_for(datetime(2026, 8, 1, 19, 0)), "Good evening")
+        self.assertEqual(greeting_for(datetime(2026, 8, 1, 23, 0)), "Good night")
+
+    def test_spoken_time_has_no_leading_zero(self):
+        self.assertEqual(spoken_time(datetime(2026, 8, 1, 9, 5)), "9:05 AM")
+
+    def test_spoken_date_is_readable(self):
+        self.assertEqual(spoken_date(datetime(2026, 8, 1)), "Saturday, 1 August 2026")
+
+
+class NormaliseTests(unittest.TestCase):
+    def test_punctuation_and_case_are_removed(self):
+        self.assertEqual(commands.normalise("What's the TIME??"), "what's the time")
+
+    def test_wake_word_is_stripped(self):
+        self.assertEqual(commands.normalise("Hey Capsule, battery", "capsule"), "battery")
+        self.assertEqual(commands.normalise("capsule news", "capsule"), "news")
+
+    def test_wake_word_inside_sentence_is_kept(self):
+        self.assertEqual(commands.normalise("what is a capsule", "capsule"),
+                         "what is a capsule")
+
+
+class RouterTests(unittest.TestCase):
+    def setUp(self):
+        self.router = commands.CommandRouter()
+
+    def assert_intent(self, utterance: str, expected: str):
+        result = self.router.match(commands.normalise(utterance, "capsule"))
+        self.assertIsNotNone(result, f"no intent matched {utterance!r}")
+        self.assertEqual(result[0].name, expected, f"wrong intent for {utterance!r}")
+
+    def test_utterances_route_to_the_expected_intent(self):
+        cases = {
+            "hello there": "greet",
+            "what is the time": "time",
+            "today's date": "date",
+            "what is the weather": "weather",
+            "weather in Mumbai": "weather",
+            "read me the news": "news",
+            "battery status": "battery",
+            "take a screenshot": "screenshot",
+            "read my clipboard": "clipboard",
+            "system info": "system",
+            "play file ~/Music/song.mp3": "open_media",
+            "shutdown": "power",
+            "log out": "power",
+            "play shape of you": "youtube",
+            "who is Alan Turing": "wikipedia",
+            "tell me about neural networks": "wikipedia",
+            "google best ML projects": "google",
+            "help": "help",
+            "exit": "exit",
+        }
+        for utterance, expected in cases.items():
+            with self.subTest(utterance=utterance):
+                self.assert_intent(utterance, expected)
+
+    def test_time_intent_wins_over_wikipedia_lookup(self):
+        # "what is ..." is also the Wikipedia trigger, so ordering matters.
+        self.assert_intent("what is the time", "time")
+
+    def test_media_playback_wins_over_youtube(self):
+        self.assert_intent("play file /tmp/clip.mp4", "open_media")
+
+    def test_unknown_command_is_reported_but_not_fatal(self):
+        assistant, _, _ = build_assistant()
+        response = assistant.handle("make me a sandwich")
+        self.assertFalse(response.handled)
+        self.assertIn("did not understand", response.text)
+
+    def test_empty_input_is_ignored(self):
+        assistant, _, _ = build_assistant()
+        self.assertFalse(assistant.handle("   ").handled)
+
+    def test_help_lists_every_documented_command(self):
+        text = self.router.help_text()
+        for intent in self.router.intents:
+            if intent.help:
+                self.assertIn(intent.help, text)
+
+    def test_exit_sets_the_exit_flag(self):
+        assistant, _, _ = build_assistant()
+        self.assertTrue(assistant.handle("bye").should_exit)
+
+
+class BrowserIntentTests(unittest.TestCase):
+    def test_google_opens_the_expected_url(self):
+        assistant, opened, _ = build_assistant()
+        assistant.handle("google machine learning")
+        self.assertEqual(opened, ["https://www.google.com/search?q=machine+learning"])
+
+    def test_youtube_opens_the_expected_url(self):
+        assistant, opened, _ = build_assistant()
+        assistant.handle("play lofi beats")
+        self.assertEqual(
+            opened, ["https://www.youtube.com/results?search_query=lofi+beats"]
+        )
+
+    def test_url_builders_escape_special_characters(self):
+        self.assertEqual(
+            knowledge.google_search_url("c++ & python"),
+            "https://www.google.com/search?q=c%2B%2B+%26+python",
+        )
+
+    def test_trim_sentences_respects_the_limit(self):
+        text = "One. Two. Three. Four."
+        self.assertEqual(knowledge.trim_sentences(text, 2), "One. Two.")
+        self.assertEqual(knowledge.trim_sentences(text, 0), text)
+
+
+class WeatherParsingTests(unittest.TestCase):
+    def test_wttr_payload_is_parsed(self):
+        payload = {
+            "current_condition": [
+                {
+                    "temp_C": "29",
+                    "FeelsLikeC": "33",
+                    "humidity": "74",
+                    "windspeedKmph": "11",
+                    "weatherDesc": [{"value": "Partly cloudy"}],
+                }
+            ]
+        }
+        report = live_data.parse_wttr_payload(payload, "Jamshedpur")
+        self.assertEqual(report.temperature_c, 29)
+        self.assertEqual(report.humidity, 74)
+        self.assertIn("Partly cloudy in Jamshedpur", report.describe())
+        self.assertIn("29 degrees Celsius", report.describe())
+
+    def test_openweather_payload_converts_wind_to_kmph(self):
+        payload = {
+            "name": "Jamshedpur",
+            "weather": [{"description": "light rain"}],
+            "main": {"temp": 27.4, "feels_like": 30.1, "humidity": 88},
+            "wind": {"speed": 5},
+        }
+        report = live_data.parse_openweather_payload(payload, "Jamshedpur")
+        self.assertAlmostEqual(report.wind_kmph, 18.0)
+        self.assertIn("Light rain in Jamshedpur", report.describe())
+
+    def test_malformed_payload_does_not_raise(self):
+        report = live_data.parse_wttr_payload({}, "Nowhere")
+        self.assertEqual(report.temperature_c, 0.0)
+        self.assertIn("Nowhere", report.describe())
+
+
+class CityParsingTests(unittest.TestCase):
+    def test_city_is_title_cased_after_normalisation(self):
+        self.assertEqual(commands.clean_city("new delhi"), "New Delhi")
+
+    def test_trailing_filler_words_are_dropped(self):
+        self.assertEqual(commands.clean_city("mumbai today please"), "Mumbai")
+
+    def test_empty_city_falls_back_to_the_configured_default(self):
+        assistant, _, _ = build_assistant()
+        match = commands.CommandRouter().match("what is the weather")
+        self.assertIsNotNone(match)
+        self.assertEqual(commands.clean_city(match[1].groupdict().get("city") or ""), "")
+
+
+class NewsParsingTests(unittest.TestCase):
+    RSS = """<?xml version="1.0"?>
+    <rss version="2.0"><channel>
+      <item><title>First headline</title></item>
+      <item><title>Second headline</title></item>
+      <item><title>Third headline</title></item>
+    </channel></rss>"""
+
+    def test_rss_titles_are_extracted_up_to_the_limit(self):
+        self.assertEqual(
+            live_data.parse_news_rss(self.RSS, limit=2),
+            ["First headline", "Second headline"],
+        )
+
+    def test_invalid_xml_returns_no_headlines(self):
+        self.assertEqual(live_data.parse_news_rss("not xml at all"), [])
+
+    def test_headlines_are_numbered(self):
+        formatted = live_data.format_headlines(["A", "B"])
+        self.assertIn("1. A", formatted)
+        self.assertIn("2. B", formatted)
+
+    def test_empty_headlines_produce_a_friendly_message(self):
+        self.assertIn("could not fetch", live_data.format_headlines([]))
+
+
+class SystemToolTests(unittest.TestCase):
+    def test_screenshot_filename_is_timestamped(self):
+        name = system_tools.screenshot_filename(datetime(2026, 8, 1, 14, 30, 5))
+        self.assertEqual(name, "screenshot_20260801_143005.png")
+
+    def test_battery_description_includes_state_and_runtime(self):
+        status = system_tools.BatteryStatus(percent=76.4, plugged=False, seconds_left=5400)
+        described = status.describe()
+        self.assertIn("76 percent", described)
+        self.assertIn("on battery", described)
+        self.assertIn("1 hours and 30 minutes", described)
+
+    def test_plugged_battery_hides_the_runtime_estimate(self):
+        status = system_tools.BatteryStatus(percent=100, plugged=True, seconds_left=None)
+        self.assertIn("charging", status.describe())
+        self.assertEqual(system_tools.format_seconds_left(None, True), "")
+
+    def test_open_media_rejects_a_missing_path(self):
+        ok, message = system_tools.open_media("/definitely/not/here.mp3")
+        self.assertFalse(ok)
+        self.assertIn("could not find", message.lower())
+
+    def test_power_argv_is_defined_per_platform(self):
+        self.assertEqual(system_tools.power_argv("restart", "Windows"),
+                         ["shutdown", "/r", "/t", "5"])
+        self.assertEqual(system_tools.power_argv("nonsense", "Windows"), [])
+
+
+class PowerSafetyTests(unittest.TestCase):
+    """Power controls must never fire without opt-in *and* confirmation."""
+
+    def test_power_is_refused_while_disabled(self):
+        calls: list[list[str]] = []
+        config = AssistantConfig(allow_power_commands=False)
+        ok, message = system_tools.run_power_command(
+            "shutdown", config, confirm=lambda action: True, runner=calls.append
+        )
+        self.assertFalse(ok)
+        self.assertEqual(calls, [])
+        self.assertIn("disabled", message)
+
+    def test_power_is_refused_when_confirmation_is_declined(self):
+        calls: list[list[str]] = []
+        config = AssistantConfig(allow_power_commands=True)
+        ok, message = system_tools.run_power_command(
+            "restart", config, confirm=lambda action: False, runner=calls.append
+        )
+        self.assertFalse(ok)
+        self.assertEqual(calls, [])
+        self.assertIn("Cancelled", message)
+
+    def test_power_runs_only_after_opt_in_and_confirmation(self):
+        calls: list[list[str]] = []
+        config = AssistantConfig(allow_power_commands=True)
+        ok, message = system_tools.run_power_command(
+            "logout", config, confirm=lambda action: True, runner=calls.append
+        )
+        self.assertTrue(ok)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("issued", message)
+
+    def test_unknown_power_action_is_rejected(self):
+        ok, message = system_tools.run_power_command("explode", AssistantConfig())
+        self.assertFalse(ok)
+        self.assertIn("not a supported", message)
+
+    def test_shutdown_intent_is_blocked_by_default(self):
+        assistant, _, _ = build_assistant()
+        self.assertIn("disabled", assistant.handle("shutdown").text)
+
+
+class ConfigTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._saved)
+
+    def test_defaults_target_jamshedpur(self):
+        for key in ("ASSISTANT_CITY", "ASSISTANT_ALLOW_POWER", "ASSISTANT_HEADLINES"):
+            os.environ.pop(key, None)
+        config = load_config()
+        self.assertEqual(config.city, "Jamshedpur")
+        self.assertFalse(config.allow_power_commands)
+
+    def test_environment_overrides_are_applied(self):
+        os.environ["ASSISTANT_CITY"] = "Bengaluru"
+        os.environ["ASSISTANT_HEADLINES"] = "3"
+        os.environ["ASSISTANT_ALLOW_POWER"] = "true"
+        config = load_config()
+        self.assertEqual(config.city, "Bengaluru")
+        self.assertEqual(config.max_headlines, 3)
+        self.assertTrue(config.allow_power_commands)
+
+    def test_malformed_numeric_values_fall_back_to_defaults(self):
+        os.environ["ASSISTANT_HEADLINES"] = "many"
+        self.assertEqual(load_config().max_headlines, 5)
+
+    def test_screenshot_target_joins_the_configured_folder(self):
+        config = AssistantConfig(screenshot_dir=Path("/tmp/shots"))
+        self.assertEqual(config.screenshot_target("a.png"), Path("/tmp/shots/a.png"))
+
+
+class CliTests(unittest.TestCase):
+    def test_parser_reads_every_flag(self):
+        from assistant.cli import build_parser
+
+        args = build_parser().parse_args(
+            ["--voice", "--no-tts", "--allow-power", "--city", "Pune", "--say", "battery"]
+        )
+        self.assertTrue(args.voice and args.no_tts and args.allow_power)
+        self.assertEqual(args.city, "Pune")
+        self.assertEqual(args.say, "battery")
+
+    def test_defaults_are_conservative(self):
+        from assistant.cli import build_parser
+
+        args = build_parser().parse_args([])
+        self.assertFalse(args.voice or args.no_tts or args.allow_power)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Voice_CLI_Virtual_Assistant/voice_cli_assistant_demo.ipynb
+++ b/Voice_CLI_Virtual_Assistant/voice_cli_assistant_demo.ipynb
@@ -1,0 +1,756 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-01",
+   "metadata": {},
+   "source": [
+    "# 🎙️ Voice & CLI-Driven System Virtual Assistant — Walkthrough\n",
+    "\n",
+    "This notebook is a guided tour of the assistant that lives in this folder. It explains\n",
+    "**how each layer works** and runs the pieces that are safe to execute inside a notebook.\n",
+    "\n",
+    "| Layer | Module | What it does |\n",
+    "|---|---|---|\n",
+    "| Speech & NLP | `assistant/speech.py` | time-aware greetings, offline TTS, microphone STT |\n",
+    "| Intent routing | `assistant/commands.py` | regex intent router that turns an utterance into an action |\n",
+    "| Knowledge | `assistant/knowledge.py` | Wikipedia summaries, Google search, YouTube playback |\n",
+    "| Live data | `assistant/live_data.py` | weather + top news headlines (keyless providers) |\n",
+    "| System automation | `assistant/system_tools.py` | clipboard, screenshots, battery, media, power controls |\n",
+    "| Orchestration | `assistant/core.py`, `assistant/cli.py` | the assistant object and its command line |\n",
+    "\n",
+    "> **Note on safety** — screenshots, media playback and power commands touch the host\n",
+    "> machine, so this notebook demonstrates them through injected test doubles rather than\n",
+    "> firing them for real. The interactive assistant (`python main.py`) is where they run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.411982Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.411866Z",
+     "iopub.status.idle": "2026-07-31T19:48:03.428004Z",
+     "shell.execute_reply": "2026-07-31T19:48:03.427329Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "assistant package v1.0.0\n",
+      "python 3.14.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "from datetime import datetime\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# The notebook lives next to the package, so the project folder is the import root.\n",
+    "PROJECT_ROOT = Path.cwd()\n",
+    "if not (PROJECT_ROOT / \"assistant\").is_dir():\n",
+    "    PROJECT_ROOT = PROJECT_ROOT / \"Voice_CLI_Virtual_Assistant\"\n",
+    "sys.path.insert(0, str(PROJECT_ROOT))\n",
+    "\n",
+    "import assistant\n",
+    "from assistant import commands, knowledge, live_data, system_tools\n",
+    "from assistant.config import AssistantConfig, load_config\n",
+    "from assistant.core import VirtualAssistant\n",
+    "from assistant.speech import greeting_for, spoken_date, spoken_time\n",
+    "\n",
+    "print(f\"assistant package v{assistant.__version__}\")\n",
+    "print(f\"python {sys.version.split()[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-03",
+   "metadata": {},
+   "source": [
+    "## 1. Speech layer — time-aware greetings\n",
+    "\n",
+    "`greeting_for()` is a pure function of the clock, which keeps it trivially testable.\n",
+    "The same helper drives the greeting spoken at start-up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.429814Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.429677Z",
+     "iopub.status.idle": "2026-07-31T19:48:03.432638Z",
+     "shell.execute_reply": "2026-07-31T19:48:03.432068Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "08:00 -> Good morning\n",
+      "13:00 -> Good afternoon\n",
+      "19:00 -> Good evening\n",
+      "23:00 -> Good night\n",
+      "\n",
+      "spoken time: 9:05 AM\n",
+      "spoken date: Saturday, 1 August 2026\n"
+     ]
+    }
+   ],
+   "source": [
+    "for hour in (8, 13, 19, 23):\n",
+    "    moment = datetime(2026, 8, 1, hour, 0)\n",
+    "    print(f\"{moment:%H:%M} -> {greeting_for(moment)}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"spoken time:\", spoken_time(datetime(2026, 8, 1, 9, 5)))\n",
+    "print(\"spoken date:\", spoken_date(datetime(2026, 8, 1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {},
+   "source": [
+    "Text-to-speech (`pyttsx3`) and speech-to-text (`SpeechRecognition`) are imported\n",
+    "**lazily**. If the host has no audio driver or no microphone, the engine quietly falls\n",
+    "back to printing responses and reading typed input — the assistant never crashes because\n",
+    "of missing hardware."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.434044Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.433910Z",
+     "iopub.status.idle": "2026-07-31T19:48:03.438691Z",
+     "shell.execute_reply": "2026-07-31T19:48:03.438063Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TTS available : False\n",
+      "STT available : False\n",
+      "\n",
+      "assistant > This is what a spoken response looks like in text mode.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'This is what a spoken response looks like in text mode.'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from assistant.speech import SpeechEngine\n",
+    "\n",
+    "engine = SpeechEngine(load_config(), enable_tts=False, enable_stt=False)\n",
+    "print(\"TTS available :\", engine.tts_available)\n",
+    "print(\"STT available :\", engine.stt_available)\n",
+    "print()\n",
+    "engine.speak(\"This is what a spoken response looks like in text mode.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-07",
+   "metadata": {},
+   "source": [
+    "## 2. Intent routing\n",
+    "\n",
+    "Every utterance — typed or transcribed — is normalised (lower-cased, punctuation removed,\n",
+    "wake word stripped) and then matched against an **ordered** list of regex intents.\n",
+    "\n",
+    "Ordering matters: `what is the time` must beat the catch-all `what is <topic>` Wikipedia\n",
+    "lookup, and `play file <path>` must beat `play <song>`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.439984Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.439887Z",
+     "iopub.status.idle": "2026-07-31T19:48:03.442733Z",
+     "shell.execute_reply": "2026-07-31T19:48:03.442138Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"what's the time\"\n",
+      "': read me the news'\n",
+      "'what is a capsule'\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(repr(commands.normalise(\"Hey Capsule, what's the TIME??\", wake_word=\"capsule\")))\n",
+    "print(repr(commands.normalise(\"CAPSULE: read me the news!\", wake_word=\"capsule\")))\n",
+    "# A wake word in the middle of a sentence is left alone.\n",
+    "print(repr(commands.normalise(\"what is a capsule\", wake_word=\"capsule\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.444078Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.443958Z",
+     "iopub.status.idle": "2026-07-31T19:48:03.450980Z",
+     "shell.execute_reply": "2026-07-31T19:48:03.450341Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "utterance                        -> intent\n",
+      "----------------------------------------------------\n",
+      "hello there                      -> greet\n",
+      "what is the time                 -> time\n",
+      "todays date                      -> date\n",
+      "weather in Mumbai                -> weather\n",
+      "read me the news                 -> news\n",
+      "battery status                   -> battery\n",
+      "take a screenshot                -> screenshot\n",
+      "read my clipboard                -> clipboard\n",
+      "system info                      -> system\n",
+      "play file ~/Music/song.mp3       -> open_media\n",
+      "play shape of you                -> youtube\n",
+      "who is Alan Turing               -> wikipedia\n",
+      "google best ML projects          -> google\n",
+      "shutdown                         -> power\n",
+      "make me a sandwich               -> (unmatched)\n"
+     ]
+    }
+   ],
+   "source": [
+    "router = commands.CommandRouter()\n",
+    "\n",
+    "utterances = [\n",
+    "    \"hello there\",\n",
+    "    \"what is the time\",\n",
+    "    \"todays date\",\n",
+    "    \"weather in Mumbai\",\n",
+    "    \"read me the news\",\n",
+    "    \"battery status\",\n",
+    "    \"take a screenshot\",\n",
+    "    \"read my clipboard\",\n",
+    "    \"system info\",\n",
+    "    \"play file ~/Music/song.mp3\",\n",
+    "    \"play shape of you\",\n",
+    "    \"who is Alan Turing\",\n",
+    "    \"google best ML projects\",\n",
+    "    \"shutdown\",\n",
+    "    \"make me a sandwich\",\n",
+    "]\n",
+    "\n",
+    "print(f\"{'utterance':<32} -> intent\")\n",
+    "print(\"-\" * 52)\n",
+    "for text in utterances:\n",
+    "    result = router.match(commands.normalise(text, \"capsule\"))\n",
+    "    print(f\"{text:<32} -> {result[0].name if result else '(unmatched)'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## 3. Live-data parsers\n",
+    "\n",
+    "Network access is confined to the `fetch_*` helpers; the payload parsers are pure\n",
+    "functions, so they can be exercised here with fixtures — no network, no API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.452546Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.452421Z",
+     "iopub.status.idle": "2026-07-31T19:48:03.455422Z",
+     "shell.execute_reply": "2026-07-31T19:48:03.454926Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Partly cloudy in Jamshedpur. It is 29 degrees Celsius and feels like 33, with 74% humidity and 11 kilometres per hour of wind.\n",
+      "Light rain in Jamshedpur. It is 27 degrees Celsius and feels like 30, with 88% humidity and 18 kilometres per hour of wind.\n"
+     ]
+    }
+   ],
+   "source": [
+    "wttr_payload = {\n",
+    "    \"current_condition\": [{\n",
+    "        \"temp_C\": \"29\", \"FeelsLikeC\": \"33\", \"humidity\": \"74\",\n",
+    "        \"windspeedKmph\": \"11\", \"weatherDesc\": [{\"value\": \"Partly cloudy\"}],\n",
+    "    }]\n",
+    "}\n",
+    "print(live_data.parse_wttr_payload(wttr_payload, \"Jamshedpur\").describe())\n",
+    "\n",
+    "openweather_payload = {\n",
+    "    \"name\": \"Jamshedpur\",\n",
+    "    \"weather\": [{\"description\": \"light rain\"}],\n",
+    "    \"main\": {\"temp\": 27.4, \"feels_like\": 30.1, \"humidity\": 88},\n",
+    "    \"wind\": {\"speed\": 5},  # m/s, converted to km/h by the parser\n",
+    "}\n",
+    "print(live_data.parse_openweather_payload(openweather_payload, \"Jamshedpur\").describe())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.457003Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.456906Z",
+     "iopub.status.idle": "2026-07-31T19:48:03.460323Z",
+     "shell.execute_reply": "2026-07-31T19:48:03.459804Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Here are the top 3 headlines.\n",
+      "1. First headline\n",
+      "2. Second headline\n",
+      "3. Third headline\n",
+      "\n",
+      "malformed feed -> []\n"
+     ]
+    }
+   ],
+   "source": [
+    "rss = '''<?xml version=\"1.0\"?>\n",
+    "<rss version=\"2.0\"><channel>\n",
+    "  <item><title>First headline</title></item>\n",
+    "  <item><title>Second headline</title></item>\n",
+    "  <item><title>Third headline</title></item>\n",
+    "</channel></rss>'''\n",
+    "\n",
+    "print(live_data.format_headlines(live_data.parse_news_rss(rss, limit=3)))\n",
+    "print()\n",
+    "# A malformed feed degrades to an empty list rather than raising.\n",
+    "print(\"malformed feed ->\", live_data.parse_news_rss(\"not xml at all\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {},
+   "source": [
+    "### Optional: live providers\n",
+    "\n",
+    "Both providers work **without an API key**: weather falls back to `wttr.in` and news to the\n",
+    "Google News RSS feed. Export `OPENWEATHER_API_KEY` / `NEWSAPI_KEY` to use those services\n",
+    "instead. The cell below is wrapped so the notebook still runs offline (for example in CI)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:03.461641Z",
+     "iopub.status.busy": "2026-07-31T19:48:03.461543Z",
+     "iopub.status.idle": "2026-07-31T19:48:05.014291Z",
+     "shell.execute_reply": "2026-07-31T19:48:05.013364Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "city: Jamshedpur | OpenWeather key set: False | NewsAPI key set: False\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mist in Jamshedpur. It is 26 degrees Celsius and feels like 30, with 95% humidity and 4 kilometres per hour of wind.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Here are the top 3 headlines.\n",
+      "1. 'Want To Forgive Them': PM Modi On Students Who Abused Him at Jantar Mantar - NDTV\n",
+      "2. Spain deploys military to Ceuta after migrant surge: What we know - Al Jazeera\n",
+      "3. 'Pak-trained Mujahideen have turned their guns inwards': India slams Islamabad over PoK crackdown - The Times of India\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = load_config()\n",
+    "print(f\"city: {config.city} | OpenWeather key set: {bool(config.openweather_api_key)} \"\n",
+    "      f\"| NewsAPI key set: {bool(config.newsapi_key)}\")\n",
+    "\n",
+    "try:\n",
+    "    print()\n",
+    "    print(live_data.fetch_weather(config.city, config))\n",
+    "    print()\n",
+    "    print(live_data.format_headlines(live_data.fetch_headlines(config, limit=3)))\n",
+    "except Exception as exc:  # offline execution keeps the notebook runnable\n",
+    "    print(f\"live lookup skipped: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {},
+   "source": [
+    "## 4. Knowledge integrations\n",
+    "\n",
+    "URL builders are pure functions, so the exact URL that would be opened can be asserted\n",
+    "without launching a browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:05.016774Z",
+     "iopub.status.busy": "2026-07-31T19:48:05.016568Z",
+     "iopub.status.idle": "2026-07-31T19:48:05.020375Z",
+     "shell.execute_reply": "2026-07-31T19:48:05.019672Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://www.google.com/search?q=best+ML+projects\n",
+      "https://www.youtube.com/results?search_query=lofi+beats\n",
+      "https://www.google.com/search?q=c%2B%2B+%26+python\n",
+      "would open: ['https://www.youtube.com/results?search_query=shape+of+you']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(knowledge.google_search_url(\"best ML projects\"))\n",
+    "print(knowledge.youtube_search_url(\"lofi beats\"))\n",
+    "print(knowledge.google_search_url(\"c++ & python\"))  # special characters are escaped\n",
+    "\n",
+    "# `open_in_browser` takes an injectable opener, which is how the tests stay headless.\n",
+    "opened = []\n",
+    "knowledge.play_on_youtube(\"shape of you\", opener=opened.append)\n",
+    "print(\"would open:\", opened)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-17",
+   "metadata": {},
+   "source": [
+    "## 5. System automation & telemetry\n",
+    "\n",
+    "`psutil`, `pyautogui` and `pyperclip` are all optional. Each helper returns a readable\n",
+    "message instead of raising when its dependency (or the hardware) is missing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:05.022035Z",
+     "iopub.status.busy": "2026-07-31T19:48:05.021885Z",
+     "iopub.status.idle": "2026-07-31T19:48:05.029919Z",
+     "shell.execute_reply": "2026-07-31T19:48:05.029351Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "host: Darwin 25.5.0 on arm64, running Python 3.14.\n",
+      "screenshot name: screenshot_20260801_143005.png\n",
+      "battery: The battery is at 76 percent and on battery. About 7 hours and 41 minutes remaining.\n",
+      "sample : The battery is at 76 percent and on battery. About 1 hours and 30 minutes remaining.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"host:\", system_tools.system_summary())\n",
+    "print(\"screenshot name:\", system_tools.screenshot_filename(datetime(2026, 8, 1, 14, 30, 5)))\n",
+    "\n",
+    "battery = system_tools.battery_status()\n",
+    "print(\"battery:\", battery.describe() if battery else \"no battery detected on this host\")\n",
+    "\n",
+    "# Formatting is a pure function, so the description is verifiable with a fixture.\n",
+    "sample = system_tools.BatteryStatus(percent=76.4, plugged=False, seconds_left=5400)\n",
+    "print(\"sample :\", sample.describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {},
+   "source": [
+    "## 6. Safety model for destructive actions\n",
+    "\n",
+    "Shutdown / restart / logout sit behind **two independent gates**:\n",
+    "\n",
+    "1. they are disabled unless the user opts in (`--allow-power`, or `ASSISTANT_ALLOW_POWER=1`);\n",
+    "2. even then, the user must type the action name to confirm.\n",
+    "\n",
+    "The cell below proves both gates hold, using a recording runner so nothing is executed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cell-20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:05.031714Z",
+     "iopub.status.busy": "2026-07-31T19:48:05.031591Z",
+     "iopub.status.idle": "2026-07-31T19:48:05.035506Z",
+     "shell.execute_reply": "2026-07-31T19:48:05.034884Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gate 1 -> ran=False\n",
+      "         Power commands are disabled. Restart me with --allow-power to enable 'shutdown' (it would run: osascript -e tell app \"System Events\" to shut down).\n",
+      "\n",
+      "gate 2 -> ran=False\n",
+      "         Cancelled the restart request.\n",
+      "\n",
+      "both   -> ran=True\n",
+      "         Logout command issued.\n",
+      "\n",
+      "commands actually dispatched: [['osascript', '-e', 'tell app \"System Events\" to log out']]\n"
+     ]
+    }
+   ],
+   "source": [
+    "executed = []\n",
+    "\n",
+    "# Gate 1 - opt-in missing: the command is described, never run.\n",
+    "ok, message = system_tools.run_power_command(\n",
+    "    \"shutdown\", AssistantConfig(allow_power_commands=False),\n",
+    "    confirm=lambda action: True, runner=executed.append,\n",
+    ")\n",
+    "print(f\"gate 1 -> ran={ok}\\n         {message}\\n\")\n",
+    "\n",
+    "# Gate 2 - opted in, but confirmation declined.\n",
+    "ok, message = system_tools.run_power_command(\n",
+    "    \"restart\", AssistantConfig(allow_power_commands=True),\n",
+    "    confirm=lambda action: False, runner=executed.append,\n",
+    ")\n",
+    "print(f\"gate 2 -> ran={ok}\\n         {message}\\n\")\n",
+    "\n",
+    "# Both gates satisfied - only now is a command issued (to the recording runner).\n",
+    "ok, message = system_tools.run_power_command(\n",
+    "    \"logout\", AssistantConfig(allow_power_commands=True),\n",
+    "    confirm=lambda action: True, runner=executed.append,\n",
+    ")\n",
+    "print(f\"both   -> ran={ok}\\n         {message}\\n\")\n",
+    "print(\"commands actually dispatched:\", executed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-21",
+   "metadata": {},
+   "source": [
+    "## 7. Driving the whole assistant\n",
+    "\n",
+    "`VirtualAssistant` accepts injected collaborators, so a complete end-to-end conversation\n",
+    "can be replayed here without a microphone, a browser or a real power command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:48:05.037384Z",
+     "iopub.status.busy": "2026-07-31T19:48:05.037254Z",
+     "iopub.status.idle": "2026-07-31T19:48:05.042149Z",
+     "shell.execute_reply": "2026-07-31T19:48:05.041569Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "you       > Hey Capsule, hello!\n",
+      "assistant > Good morning! How can I help you?\n",
+      "\n",
+      "you       > what is the time\n",
+      "assistant > The time is 1:18 AM.\n",
+      "\n",
+      "you       > google machine learning roadmap\n",
+      "assistant > Searching Google for machine learning roadmap. Opened https://www.google.com/search?q=machine+learning+roadmap\n",
+      "\n",
+      "you       > play lofi beats\n",
+      "assistant > Opening YouTube results for lofi beats. Opened https://www.youtube.com/results?search_query=lofi+beats\n",
+      "\n",
+      "you       > shutdown\n",
+      "assistant > Power commands are disabled. Restart me with --allow-power to enable 'shutdown' (it would run: osascript -e tell app \"System Events\" to shut down).\n",
+      "\n",
+      "you       > make me a sandwich\n",
+      "assistant > I did not understand that. Say 'help' to see what I can do.   <- not understood\n",
+      "\n",
+      "you       > bye\n",
+      "assistant > Goodbye! Shutting down the assistant.\n",
+      "[session ended]\n",
+      "\n",
+      "URLs the assistant would have opened:\n",
+      "   https://www.google.com/search?q=machine+learning+roadmap\n",
+      "   https://www.youtube.com/results?search_query=lofi+beats\n"
+     ]
+    }
+   ],
+   "source": [
+    "class RecordingSpeech:\n",
+    "    \"\"\"Stands in for the speech engine and records what would be spoken.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self.spoken, self.enable_stt, self.stt_available = [], False, False\n",
+    "\n",
+    "    def speak(self, text):\n",
+    "        self.spoken.append(text)\n",
+    "        return text\n",
+    "\n",
+    "\n",
+    "opened_urls = []\n",
+    "speech = RecordingSpeech()\n",
+    "bot = VirtualAssistant(\n",
+    "    config=AssistantConfig(city=\"Jamshedpur\", wake_word=\"capsule\"),\n",
+    "    speech=speech,\n",
+    "    opener=opened_urls.append,\n",
+    "    confirm=lambda action: False,\n",
+    ")\n",
+    "\n",
+    "conversation = [\n",
+    "    \"Hey Capsule, hello!\",\n",
+    "    \"what is the time\",\n",
+    "    \"google machine learning roadmap\",\n",
+    "    \"play lofi beats\",\n",
+    "    \"shutdown\",\n",
+    "    \"make me a sandwich\",\n",
+    "    \"bye\",\n",
+    "]\n",
+    "\n",
+    "for line in conversation:\n",
+    "    response = bot.respond(line)\n",
+    "    flag = \"\" if response.handled else \"   <- not understood\"\n",
+    "    print(f\"you       > {line}\")\n",
+    "    print(f\"assistant > {response.text}{flag}\")\n",
+    "    if response.should_exit:\n",
+    "        print(\"[session ended]\")\n",
+    "        break\n",
+    "    print()\n",
+    "\n",
+    "print()\n",
+    "print(\"URLs the assistant would have opened:\")\n",
+    "for url in opened_urls:\n",
+    "    print(\"  \", url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-23",
+   "metadata": {},
+   "source": [
+    "## 8. Running it for real\n",
+    "\n",
+    "```bash\n",
+    "cd Voice_CLI_Virtual_Assistant\n",
+    "pip install -r requirements.txt\n",
+    "\n",
+    "python main.py                       # interactive text session\n",
+    "python main.py --voice               # interactive voice session (needs a microphone)\n",
+    "python main.py --say \"weather\"       # one-shot command, handy in scripts\n",
+    "python main.py --list-commands       # print the whole command surface\n",
+    "python main.py --allow-power         # enable guarded shutdown/restart/logout\n",
+    "```\n",
+    "\n",
+    "Run the test suite (43 tests, fully offline) with:\n",
+    "\n",
+    "```bash\n",
+    "python -m unittest discover -s tests -v\n",
+    "```\n",
+    "\n",
+    "A recorded terminal session covering every command — including live weather, live news and\n",
+    "a real Wikipedia lookup — is checked in at [`assets/demo_session.txt`](assets/demo_session.txt)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Related Issue

Closes: #1984

- [x] Contributor (GSSoC)

---

## 📌 Description

### ✨ What does this PR do?

This PR adds **`Voice_CLI_Virtual_Assistant/`** — a Python, multi-modal virtual assistant that
accepts commands **two ways** (spoken into a microphone, or typed at a CLI) and answers with
synthesized speech plus text. It fetches live web intelligence, reads machine telemetry, and
can drive OS-level actions.

The design goal was that it must never crash because something is missing. Every optional
dependency is imported lazily and has a fallback, so the assistant starts and answers even
with **no audio device, no microphone and no API keys**.

### 🚀 Features implemented

**1. Speech & NLP layer**
* Dynamic time-of-day greetings (morning / afternoon / evening / night).
* Offline text-to-speech via `pyttsx3` → falls back to printed responses.
* Microphone speech-to-text via `SpeechRecognition` → falls back to typed input.
* Optional wake word (`hey capsule …`), stripped during normalisation.

**2. Web & knowledge integrations**
* Wikipedia summarisation, with a **keyless REST fallback** when the `wikipedia` package is
  absent, and a readable message on disambiguation.
* Google query launching and YouTube result streaming in the default browser.

**3. Live data orchestration**
* Real-time localized weather (**Jamshedpur** by default, or any city named in the command:
  `weather in Mumbai`).
* Live top news headlines, numbered for readability.
* **Both work with zero API keys** (`wttr.in` + Google News RSS) and automatically upgrade to
  OpenWeatherMap / NewsAPI when `OPENWEATHER_API_KEY` / `NEWSAPI_KEY` are exported.

**4. System automation engine**
* Clipboard text read-back (`pyperclip`, with `pbpaste` / `xclip` / PowerShell fallbacks).
* Timestamped desktop screenshots — `screenshot_YYYYMMDD_HHMMSS.png`.
* Live battery telemetry — percentage, charging state, estimated runtime remaining.

**5. OS-level control hooks**
* Media playback via subprocess through the platform default player
  (`open` / `xdg-open` / `os.startfile`).
* Power commands (shutdown / restart / logout) for Windows, macOS and Linux.

### 🔐 Safety model for the power commands

Shutdown / restart / logout are the only irreversible actions here, so they sit behind **two
independent gates** — the command is disabled unless the user opts in with `--allow-power`,
and even then the user must type the action name to confirm. Unit tests assert that **no
command is ever dispatched** unless both gates are satisfied.

```text
$ python main.py --no-tts --say "shutdown"            # gate 1
assistant > Power commands are disabled. Restart me with --allow-power to enable
            'shutdown' (it would run: osascript -e tell app "System Events" to shut down).

$ python main.py --no-tts --allow-power --say "restart"   # gate 2
Type 'restart' to confirm, anything else cancels: no
assistant > Cancelled the restart request.
```

### 🧱 Architecture

Small, independently testable modules rather than one long script:

```
Voice_CLI_Virtual_Assistant/
├── main.py                          # launcher
├── requirements.txt
├── assistant/
│   ├── config.py                    # env-driven settings
│   ├── speech.py                    # TTS + STT with fallbacks
│   ├── knowledge.py                 # Wikipedia / Google / YouTube
│   ├── live_data.py                 # weather + news providers and pure parsers
│   ├── system_tools.py              # clipboard, screenshot, battery, media, power
│   ├── commands.py                  # regex intent router
│   ├── core.py                      # VirtualAssistant orchestration
│   └── cli.py                       # argument parsing and loops
├── tests/test_assistant.py          # 43 offline unit tests
├── assets/demo_session.txt          # recorded terminal session
└── voice_cli_assistant_demo.ipynb   # annotated walkthrough notebook (executed)
```

### 🧰 Tech Stack

`pyttsx3` · `SpeechRecognition` · `wikipedia` · `requests` · `pyautogui` · `psutil` ·
`pyperclip` — plus standard library only (`argparse`, `subprocess`, `webbrowser`,
`xml.etree`, `dataclasses`, `pathlib`). Only `requests` is actually required; the rest are
optional and detected at runtime.

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

## How Has This Been Tested?

Verified on macOS (Darwin 25.5.0, arm64, Python 3.14), with `requests`, `psutil`,
`wikipedia`, `pyperclip`, `pyttsx3` and `SpeechRecognition` installed and `pyautogui`
deliberately **not** installed, so the degradation paths were exercised too.

**1. Unit tests — 43 passed, fully offline** (no microphone, browser or network):

```text
$ python -m unittest discover -s tests
Ran 43 tests in 0.007s

OK
```

Coverage includes intent routing and priority ordering, wake-word normalisation, weather and
RSS payload parsing, battery formatting, URL escaping, config/env handling, CLI flags and the
power-command safety gates.

**2. PEP 8** — `pycodestyle --max-line-length=100 assistant/ tests/ main.py` reports no issues.

**3. Live end-to-end run** — full recorded session is committed at
[`Voice_CLI_Virtual_Assistant/assets/demo_session.txt`](https://github.com/Niketkumardheeryan/ML-CaPsule/blob/a5fa70c6bff1f94e7262ea9170569424ac918ab2/Voice_CLI_Virtual_Assistant/assets/demo_session.txt),
covering every command including real weather, real news and a real Wikipedia lookup.

**4. Notebook** — `voice_cli_assistant_demo.ipynb` is committed **executed, with outputs, 0 errors**.

---

## Screenshots

Recorded terminal output (real run, not mocked):

**Interactive session**

```text
$ python main.py --no-tts
assistant > Good morning! I am your ML-CaPsule assistant, listening in text mode. Say 'help' to see what I can do.
you > hello
assistant > Good morning! How can I help you?
you > battery
assistant > The battery is at 76 percent and on battery. About 7 hours and 41 minutes remaining.
you > what is the time
assistant > The time is 1:16 AM.
you > exit
assistant > Goodbye! Shutting down the assistant.
```

**Live data, knowledge and system commands**

```text
$ python main.py --no-tts --say "weather"
assistant > Mist in Jamshedpur. It is 26 degrees Celsius and feels like 30, with 95% humidity and 4 kilometres per hour of wind.

$ python main.py --no-tts --say "weather in mumbai today"
assistant > Mist in Mumbai. It is 28 degrees Celsius and feels like 32, with 89% humidity and 35 kilometres per hour of wind.

$ python main.py --no-tts --say "news"
assistant > Here are the top 5 headlines.
1. 'Want To Forgive Them': PM Modi On Students Who Abused Him at Jantar Mantar - NDTV
2. Spain deploys military to Ceuta after migrant surge: What we know - Al Jazeera
3. 'Pak-trained Mujahideen have turned their guns inwards': India slams Islamabad over PoK crackdown - The Times of India
4. Breaking | Tahir Hussain, Others Get Life Imprisonment For Murder Of IB Staffer Ankit Sharma During Delhi ... - livelaw.in
5. At least one non-local labourer killed, another injured in terrorist shooting in J&K's Kulgam - The Hindu

$ python main.py --no-tts --say "who is Alan Turing"
assistant > According to Wikipedia: Alan Mathison Turing was an English mathematician, computer scientist, logician, cryptanalyst, philosopher and theoretical biologist. He was highly influential in the development of theoretical computer science, providing a formalisation of the concepts of algorithm and computation with the Turing machine, which can be considered a model of a general-purpose computer.

$ python main.py --no-tts --say "system info"
assistant > Darwin 25.5.0 on arm64, running Python 3.14.

$ python main.py --no-tts --say "battery"
assistant > The battery is at 77 percent and on battery. About 7 hours and 33 minutes remaining.

$ python main.py --no-tts --say "make me a sandwich"
assistant > I did not understand that. Say 'help' to see what I can do.
```

**Graceful degradation** (host without `pyautogui` and without Screen Recording permission — it reports instead of crashing):

```text
$ python main.py --no-tts --say "take a screenshot"
assistant > Screen capture is unavailable. Install pyautogui, and on macOS grant your
            terminal Screen Recording permission in System Settings > Privacy & Security.
```

**Full command surface**

```text
$ python main.py --list-commands
Here is what I can do:
  - exit / quit / bye - close the assistant
  - help - list every supported command
  - hello - time aware greeting
  - what is the time - current clock time
  - what is the date - today's date
  - weather [in <city>] - live weather report
  - news - top headlines of the day
  - battery - charge percentage and time left
  - screenshot - timestamped desktop capture
  - clipboard - read back the copied text
  - system info - host operating system summary
  - play file <path> - open media in the default player
  - shutdown / restart / logout - guarded power controls
  - play <query> - stream the top YouTube result
  - who is <topic> - Wikipedia summary
  - google <query> - open Google results
```

---

## Checklist

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules. *(n/a — no dependent changes)*

### Notes for reviewers

* No existing files were modified except the root `README.md`, where the project is added to
  the Quick Project Index and the domain table.
* The root `requirements.txt` is **untouched** (it is workflow-tracked); the project ships its
  own `Voice_CLI_Virtual_Assistant/requirements.txt`.
* This differs from the existing `GUI-JARVIS/` project, which is a PyQt desktop GUI. This one
  is voice + CLI, cross-platform, dependency-optional and unit tested.
* Suggested labels: `type:feature`, `level:intermediate`, `gssoc:approved`.

