### PR TITLE
fix: Prevent path traversal when serving the PWA static files (CodeQL alert on #2229)

### DIFF
--- a/Breast Cancer Detection using DL with Webapp/Webapp/webapp.py
+++ b/Breast Cancer Detection using DL with Webapp/Webapp/webapp.py
@@ -2,6 +2,7 @@ import os
 import time
 import logging
 from flask import Flask, request, render_template, jsonify, send_from_directory
+from werkzeug.security import safe_join
 import numpy as np
 import cv2
 import tensorflow as tf
@@ -166,8 +167,12 @@ def spa(path):
             "cd frontend && npm install && npm run build",
             404,
         )
-    if path and os.path.exists(os.path.join(FRONTEND_DIST, path)):
-        return send_from_directory(FRONTEND_DIST, path)
+    if path:
+        # safe_join returns None when `path` tries to escape the directory, so a
+        # traversal attempt can never reach os.path.isfile or be served.
+        candidate = safe_join(FRONTEND_DIST, path)
+        if candidate is not None and os.path.isfile(candidate):
+            return send_from_directory(FRONTEND_DIST, path)
     return send_from_directory(FRONTEND_DIST, 'index.html')
 
 


### PR DESCRIPTION
## Related Issue

Fixes the CodeQL alert raised on my own merged PR #2229 — code scanning alert
[#516](https://github.com/Niketkumardheeryan/ML-CaPsule/security/code-scanning/516),
*Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)*.

- [x] Contributor (GSSoC)

---

## 📌 Description

### The bug

The `/app/<path>` route I added in #2229 checked whether a requested file exists by joining
user input onto the build directory:

```python
if path and os.path.exists(os.path.join(FRONTEND_DIST, path)):
    return send_from_directory(FRONTEND_DIST, path)
```

`os.path.join` does **not** constrain the result to the base directory. Two ways out:

```python
os.path.join("/dist", "/etc/passwd")        # -> "/etc/passwd"   base discarded entirely
os.path.join("/dist", "../../etc/passwd")   # -> walks outside the directory
```

`send_from_directory` would still have refused to serve the file, so this is an
**information-disclosure / probing** issue rather than arbitrary file read — the check itself
reports whether a path exists anywhere the process can reach. Either way it should not be
possible, and it is my code, so here is the fix.

### The fix

Use `werkzeug.security.safe_join`, which returns `None` when the requested path escapes the
base directory. A traversal attempt therefore never reaches `os.path.isfile` and can never be
served. `safe_join` ships with Flask — no new dependency.

```python
if path:
    candidate = safe_join(FRONTEND_DIST, path)
    if candidate is not None and os.path.isfile(candidate):
        return send_from_directory(FRONTEND_DIST, path)
return send_from_directory(FRONTEND_DIST, 'index.html')
```

One file, +7 / −2. No behaviour change for legitimate requests.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## How Has This Been Tested?

**1. The helper, directly — the two escapes are now blocked:**

```text
input                        os.path.join ->                     safe_join ->
../../../../etc/passwd       /dist/../../../../etc/passwd        BLOCKED (None)   <-- escaped
/etc/passwd                  /etc/passwd                         BLOCKED (None)   <-- escaped
assets/app.js                /dist/assets/app.js                 /dist/assets/app.js
```

**2. Against the running Flask app**, with the PWA built:

```console
$ curl --path-as-is localhost:5000/app/../../../../etc/passwd
<!doctype html>...            # SPA fallback, no leak

$ curl --path-as-is localhost:5000/app/%2e%2e%2f%2e%2e%2fetc/passwd
<!doctype html>...            # SPA fallback, no leak

$ curl --path-as-is localhost:5000/app/assets/../../../../../etc/passwd
<!doctype html>...            # SPA fallback, no leak
```

None of the three returned a `root:` line, i.e. nothing outside the directory was reachable.

**3. Legitimate behaviour is unchanged:**

```console
$ curl -o /dev/null -w "%{http_code} %{content_type}" localhost:5000/app/assets/index-CUPGvhjs.js
200 text/javascript; charset=utf-8

$ curl -o /dev/null -w "%{http_code}" localhost:5000/app
200
```

The original `/`, `/predict`, `/api/health` and `/api/predict` routes are untouched.

---

## Checklist

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation. *(n/a — internal fix, no documented behaviour changed)*
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective. *(verified by the live traversal tests above)*
- [ ] Any dependent changes have been merged and published in downstream modules. *(n/a)*

---

### Notes for reviewers

Thanks to the CodeQL scan for catching this on #2229. Raising the fix promptly since the
vulnerable line is mine and it is already on `master`.

Suggested labels: `type:bug`, `level:beginner`, `gssoc:approved`.
