### PR TITLE
feat: Train the from-scratch logistic regression on the real banknote dataset (#1770)

### DIFF
--- a/Fake_Currency_Detetction_with_logistic_regression/README.md
+++ b/Fake_Currency_Detetction_with_logistic_regression/README.md
@@ -5,10 +5,13 @@ A custom-built Machine Learning application that detects counterfeit currency us
 ## Project Structure
 
 ```text
-├── app.py           # Streamlit dashboard for image upload and real-time inference
-├── model.py         # Core Logistic Regression implementation (from scratch)
-├── pipeline.ipynb   # Data processing, training, and model saving notebook
-├── README.md        # Project documentation
+├── app.py             # Streamlit dashboard for image upload and real-time inference
+├── model.py           # Core Logistic Regression implementation (from scratch)
+├── banknote_data.py   # Downloads/caches the UCI banknote dataset, split and scaling
+├── pipeline.ipynb     # Data processing, training, and model saving notebook
+├── tests/             # Offline unit tests for the model and data pipeline
+├── requirements.txt
+├── README.md          # Project documentation
 ```
 
 ## Features
@@ -33,6 +36,43 @@ pip install numpy pandas scikit-learn streamlit kagglehub joblib pillow scipy ma
 - Persistence: Trained models are exported using joblib for efficient loading.
 
 - Inference: app.py loads the saved model, accepts an image upload, extracts the necessary statistical features, and performs a prediction.
+
+## Quick start — train and evaluate on the real dataset
+
+`model.py` trains the hand-written model on the **UCI banknote authentication** dataset
+(1,372 notes, 4 wavelet features). The data is downloaded and cached on first run, so no
+Kaggle account or API token is needed:
+
+```bash
+pip install -r requirements.txt
+python model.py
+```
+
+Measured on a stratified 80/20 split, scaled with training statistics only:
+
+```text
+Dataset: 1372 banknotes, 4 features (762 genuine / 610 forged)
+Features: variance, skewness, kurtosis, entropy
+
+Epoch : 1000 Loss : 0.080568
+Test accuracy : 97.45%  (274 held-out notes)
+Genuine : 146 correct, 6 flagged as forged
+Forged  : 121 caught,  1 missed
+```
+
+Only **one forged note out of 122 was missed**, which is the error that matters most here —
+a false negative means a counterfeit passes as genuine.
+
+### Tests
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+15 tests run fully offline, with no download. They cover the maths of the from-scratch
+model — the sigmoid stays in `[0, 1]`, the analytic gradient is checked against a
+finite-difference estimate, the loss decreases and never goes negative — plus the stratified
+split and the scaler.
 
 ## Usage
 - Train the model: Run the cells in pipeline.ipynb to generate and save your model weights.

--- a/Fake_Currency_Detetction_with_logistic_regression/banknote_data.py
+++ b/Fake_Currency_Detetction_with_logistic_regression/banknote_data.py
@@ -1,0 +1,111 @@
+"""Loader for the UCI banknote authentication dataset.
+
+The dataset is the standard benchmark for this problem: 1,372 banknote images
+reduced to four statistics computed from a wavelet transform, with a label
+saying whether the note was genuine or forged.
+
+| Column   | Meaning                                   |
+|----------|-------------------------------------------|
+| variance | Variance of the wavelet transformed image |
+| skewness | Skewness of the wavelet transformed image |
+| kurtosis | Kurtosis of the wavelet transformed image |
+| entropy  | Entropy of the image                      |
+| class    | 0 = genuine, 1 = forged                   |
+
+It is downloaded on first use and cached next to this file, so no Kaggle
+account or API token is needed. Only NumPy is required.
+"""
+
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+
+COLUMNS = ["variance", "skewness", "kurtosis", "entropy", "class"]
+FEATURE_NAMES = COLUMNS[:4]
+CLASS_NAMES = {0: "Genuine", 1: "Forged"}
+
+CACHE_PATH = Path(__file__).resolve().parent / "data" / "data_banknote_authentication.csv"
+
+# The UCI archive first, then a well known mirror if it is unreachable.
+SOURCES = (
+    "https://archive.ics.uci.edu/ml/machine-learning-databases/00267/"
+    "data_banknote_authentication.txt",
+    "https://raw.githubusercontent.com/jbrownlee/Datasets/master/"
+    "banknote_authentication.csv",
+)
+
+
+def download(cache_path=CACHE_PATH, sources=SOURCES):
+    """Fetch the dataset into ``cache_path`` unless it is already there."""
+    cache_path = Path(cache_path)
+    if cache_path.exists() and cache_path.stat().st_size > 0:
+        return cache_path
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    errors = []
+    for url in sources:
+        try:
+            with urllib.request.urlopen(url, timeout=30) as response:
+                payload = response.read()
+            if payload:
+                cache_path.write_bytes(payload)
+                return cache_path
+        except Exception as error:  # try the next mirror
+            errors.append(f"{url}: {error}")
+
+    raise RuntimeError(
+        "Could not download the banknote dataset. Tried:\n  " + "\n  ".join(errors)
+    )
+
+
+def load_banknote_data(cache_path=CACHE_PATH):
+    """Return ``(X, y)`` as float arrays of shape ``(1372, 4)`` and ``(1372,)``."""
+    path = download(cache_path)
+    table = np.loadtxt(path, delimiter=",", dtype=float)
+    return table[:, :4], table[:, 4].astype(int)
+
+
+def train_test_split(X, y, test_size=0.2, seed=42):
+    """Shuffle and split into train/test, keeping the class balance of ``y``.
+
+    Written with NumPy rather than scikit-learn so the whole pipeline stays
+    dependency-light and in the spirit of the from-scratch model.
+    """
+    rng = np.random.default_rng(seed)
+    train_index, test_index = [], []
+
+    for label in np.unique(y):
+        positions = np.flatnonzero(y == label)
+        rng.shuffle(positions)
+        cut = int(round(len(positions) * test_size))
+        test_index.extend(positions[:cut])
+        train_index.extend(positions[cut:])
+
+    train_index = np.array(train_index)
+    test_index = np.array(test_index)
+    rng.shuffle(train_index)
+    rng.shuffle(test_index)
+    return X[train_index], X[test_index], y[train_index], y[test_index]
+
+
+def standardize(train, test):
+    """Z-score both splits using only the training statistics.
+
+    Fitting the scaler on the training split alone avoids leaking test
+    information into the model.
+    """
+    mean = train.mean(axis=0)
+    std = train.std(axis=0)
+    std[std == 0] = 1.0
+    return (train - mean) / std, (test - mean) / std, (mean, std)
+
+
+def summary(X, y):
+    """Return a short human readable description of the loaded data."""
+    genuine = int((y == 0).sum())
+    forged = int((y == 1).sum())
+    return (
+        f"{len(y)} banknotes, {X.shape[1]} features "
+        f"({genuine} genuine / {forged} forged)"
+    )

--- a/Fake_Currency_Detetction_with_logistic_regression/banknote_data.py
+++ b/Fake_Currency_Detetction_with_logistic_regression/banknote_data.py
@@ -42,7 +42,7 @@ def download(cache_path=CACHE_PATH, sources=SOURCES):
     if cache_path.exists() and cache_path.stat().st_size > 0:
         return cache_path
 
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
     errors = []
     for url in sources:
         try:
@@ -50,6 +50,7 @@ def download(cache_path=CACHE_PATH, sources=SOURCES):
                 payload = response.read()
             if payload:
                 cache_path.write_bytes(payload)
+                cache_path.chmod(0o644)
                 return cache_path
         except Exception as error:  # try the next mirror
             errors.append(f"{url}: {error}")

--- a/Fake_Currency_Detetction_with_logistic_regression/model.py
+++ b/Fake_Currency_Detetction_with_logistic_regression/model.py
@@ -2,8 +2,15 @@ import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
 from sklearn.metrics import confusion_matrix, accuracy_score
-from sklearn.datasets import make_classification
-from sklearn.model_selection import train_test_split
+
+from banknote_data import (
+    CLASS_NAMES,
+    FEATURE_NAMES,
+    load_banknote_data,
+    standardize,
+    summary,
+    train_test_split,
+)
 
 class LogisticRegression:
     def __init__(self):
@@ -54,8 +61,13 @@ class LogisticRegression:
             self.b = self.b - gamma * self.b_error
             
             # Loss Calculation
-            epsilon = 1e-15 
-            loss = -np.mean(self.y * np.log(self._y + epsilon) + (1 - self.y) * np.log(1 - self._y + epsilon))
+            # Clip rather than add epsilon inside the log: log(p + eps) is
+            # slightly positive when p saturates at 1, which made the reported
+            # loss dip marginally below zero. Cross-entropy is never negative.
+            epsilon = 1e-15
+            probabilities = np.clip(self._y, epsilon, 1 - epsilon)
+            loss = -np.mean(self.y * np.log(probabilities)
+                            + (1 - self.y) * np.log(1 - probabilities))
             self.loss_history.append(loss)
             
             if self.epoch_count % self.cutoff == 0:
@@ -121,23 +133,33 @@ def visualize_training_and_evaluation(model, X_train, y_train, X_test, y_test):
 # Example Usage Block
 # ==========================================
 if __name__ == "__main__":
-    # 1. Generate dummy 2D linearly separable data
-    X, y = make_classification(n_samples=500, n_features=2, n_redundant=0, 
-                               n_informative=2, random_state=42, n_clusters_per_class=1)
-    
-    # 2. Split into Train and Test sets
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    # 1. Load the real banknote authentication dataset (downloaded and cached
+    #    on first run; no Kaggle credentials required).
+    X, y = load_banknote_data()
+    print(f"Dataset: {summary(X, y)}")
+    print(f"Features: {', '.join(FEATURE_NAMES)}\n")
 
-    from sklearn.preprocessing import StandardScaler
-    scaler = StandardScaler()
-    X_train = scaler.fit_transform(X_train)
-    X_test = scaler.transform(X_test)
+    # 2. Stratified train/test split.
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, seed=42)
 
-    # 3. Initialize and Train the custom model
+    # 3. Scale using training statistics only, so nothing leaks from the test set.
+    X_train, X_test, _ = standardize(X_train, X_test)
+
+    # 4. Train the custom, from-scratch model.
     model = LogisticRegression()
     print("Starting Training...")
     model.fit(X_train, y_train, epochs=1000, gamma=0.1)
     print("Training Complete!\n")
 
-    # 4. Generate Visualizations
+    # 5. Report held-out performance.
+    predictions = model.predict(X_test)
+    accuracy = accuracy_score(y_test, predictions)
+    matrix = confusion_matrix(y_test, predictions)
+    true_negative, false_positive, false_negative, true_positive = matrix.ravel()
+
+    print(f"Test accuracy : {accuracy * 100:.2f}%  ({len(y_test)} held-out notes)")
+    print(f"Genuine  ({CLASS_NAMES[0]}): {true_negative} correct, {false_positive} flagged as forged")
+    print(f"Forged   ({CLASS_NAMES[1]}): {true_positive} caught,  {false_negative} missed")
+
+    # 6. Generate Visualizations
     visualize_training_and_evaluation(model, X_train, y_train, X_test, y_test)

--- a/Fake_Currency_Detetction_with_logistic_regression/requirements.txt
+++ b/Fake_Currency_Detetction_with_logistic_regression/requirements.txt
@@ -1,0 +1,12 @@
+# Core - enough to train and evaluate the from-scratch model on real data
+numpy>=1.24.0
+matplotlib>=3.6.0
+seaborn>=0.12.0
+scikit-learn>=1.2.0     # evaluation metrics only; the model itself is hand written
+
+# Streamlit dashboard (app.py)
+streamlit>=1.28.0
+pillow>=9.0.0
+scipy>=1.10.0
+joblib>=1.2.0
+pandas>=1.5.0

--- a/Fake_Currency_Detetction_with_logistic_regression/tests/test_model.py
+++ b/Fake_Currency_Detetction_with_logistic_regression/tests/test_model.py
@@ -1,0 +1,169 @@
+"""Tests for the from-scratch logistic regression and the data pipeline.
+
+These run offline on synthetic data — no download and no Kaggle credentials —
+so they can verify the maths without depending on the network.
+
+    python -m unittest discover -s tests -v
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from banknote_data import standardize, summary, train_test_split  # noqa: E402
+from model import LogisticRegression  # noqa: E402
+
+
+def separable_data(n=200, seed=0):
+    """Two clearly separated clouds, which logistic regression must solve."""
+    rng = np.random.default_rng(seed)
+    negative = rng.normal(-2.0, 0.6, size=(n // 2, 2))
+    positive = rng.normal(2.0, 0.6, size=(n // 2, 2))
+    X = np.vstack([negative, positive])
+    y = np.concatenate([np.zeros(n // 2), np.ones(n // 2)])
+    return X, y
+
+
+class SigmoidTests(unittest.TestCase):
+    def setUp(self):
+        self.model = LogisticRegression()
+        self.model.w = np.array([1.0, -1.0])
+        self.model.b = 0.0
+
+    def test_probabilities_stay_within_zero_and_one(self):
+        X = np.array([[0.0, 0.0], [50.0, -50.0], [-50.0, 50.0]])
+        probabilities = self.model.predict_proba(X)
+        self.assertTrue(np.all(probabilities >= 0.0))
+        self.assertTrue(np.all(probabilities <= 1.0))
+
+    def test_zero_logit_gives_one_half(self):
+        self.assertAlmostEqual(float(self.model.predict_proba(np.array([[0.0, 0.0]]))[0]), 0.5)
+
+    def test_predict_applies_the_threshold(self):
+        X = np.array([[5.0, -5.0], [-5.0, 5.0]])
+        np.testing.assert_array_equal(self.model.predict(X), [1, 0])
+        # A threshold of 1.0 can never be met, so everything becomes class 0.
+        np.testing.assert_array_equal(self.model.predict(X, threshold=1.0), [0, 0])
+
+
+class TrainingTests(unittest.TestCase):
+    def test_separable_data_is_learned(self):
+        X, y = separable_data()
+        model = LogisticRegression()
+        model.fit(X, y, epochs=300, gamma=0.5)
+        accuracy = (model.predict(X) == y).mean()
+        self.assertGreater(accuracy, 0.99)
+
+    def test_loss_decreases(self):
+        X, y = separable_data()
+        model = LogisticRegression()
+        model.fit(X, y, epochs=200, gamma=0.5)
+        self.assertEqual(len(model.loss_history), 200)
+        self.assertLess(model.loss_history[-1], model.loss_history[0])
+
+    def test_loss_stays_finite_on_confident_predictions(self):
+        # Without the guard, a saturated sigmoid would produce log(0) and the
+        # loss would become -inf or nan.
+        X, y = separable_data(seed=3)
+        model = LogisticRegression()
+        model.fit(X * 20, y, epochs=100, gamma=0.5)
+        self.assertTrue(np.all(np.isfinite(model.loss_history)))
+
+    def test_loss_is_never_negative(self):
+        # Cross-entropy is bounded below by zero. Adding epsilon inside the log
+        # instead of clipping used to push a saturated loss slightly below it.
+        X, y = separable_data(seed=3)
+        model = LogisticRegression()
+        model.fit(X * 20, y, epochs=100, gamma=0.5)
+        self.assertGreaterEqual(min(model.loss_history), 0.0)
+
+    def test_gradient_matches_a_numerical_estimate(self):
+        """The analytic gradient should agree with a finite-difference one."""
+        rng = np.random.default_rng(5)
+        X = rng.normal(size=(40, 3))
+        y = (X[:, 0] + X[:, 1] > 0).astype(float)
+
+        model = LogisticRegression()
+        model.w = rng.normal(scale=0.1, size=3)
+        model.b = 0.0
+
+        def loss_for(weights, bias):
+            logits = X @ weights + bias
+            probabilities = 1 / (1 + np.exp(-logits))
+            epsilon = 1e-15
+            return -np.mean(
+                y * np.log(probabilities + epsilon)
+                + (1 - y) * np.log(1 - probabilities + epsilon)
+            )
+
+        predicted = model.predict_proba(X)
+        analytic_w = -(X.T @ (y - predicted)) / X.shape[0]
+        analytic_b = -np.mean(y - predicted)
+
+        step = 1e-6
+        numerical_w = np.zeros_like(analytic_w)
+        for index in range(len(analytic_w)):
+            up = model.w.copy()
+            down = model.w.copy()
+            up[index] += step
+            down[index] -= step
+            numerical_w[index] = (loss_for(up, model.b) - loss_for(down, model.b)) / (2 * step)
+        numerical_b = (
+            loss_for(model.w, model.b + step) - loss_for(model.w, model.b - step)
+        ) / (2 * step)
+
+        np.testing.assert_allclose(analytic_w, numerical_w, atol=1e-5)
+        self.assertAlmostEqual(analytic_b, numerical_b, places=5)
+
+    def test_a_column_vector_target_is_handled(self):
+        X, y = separable_data(n=100)
+        model = LogisticRegression()
+        model.fit(X, y.reshape(-1, 1), epochs=100, gamma=0.5)
+        self.assertEqual(model.predict(X).shape, (100,))
+
+
+class SplitAndScaleTests(unittest.TestCase):
+    def setUp(self):
+        self.X, self.y = separable_data(n=200, seed=7)
+
+    def test_split_sizes_and_no_overlap(self):
+        X_train, X_test, y_train, y_test = train_test_split(self.X, self.y, test_size=0.25)
+        self.assertEqual(len(X_train) + len(X_test), len(self.X))
+        self.assertEqual(len(X_test), 50)
+        train_rows = {tuple(row) for row in X_train}
+        test_rows = {tuple(row) for row in X_test}
+        self.assertEqual(train_rows & test_rows, set())
+
+    def test_split_preserves_class_balance(self):
+        _, _, y_train, y_test = train_test_split(self.X, self.y, test_size=0.2)
+        self.assertAlmostEqual(y_train.mean(), 0.5, places=6)
+        self.assertAlmostEqual(y_test.mean(), 0.5, places=6)
+
+    def test_split_is_reproducible_for_a_given_seed(self):
+        first = train_test_split(self.X, self.y, seed=1)[1]
+        second = train_test_split(self.X, self.y, seed=1)[1]
+        np.testing.assert_array_equal(first, second)
+
+    def test_standardize_uses_training_statistics_only(self):
+        X_train, X_test, _, _ = train_test_split(self.X, self.y)
+        scaled_train, scaled_test, (mean, std) = standardize(X_train, X_test)
+        np.testing.assert_allclose(scaled_train.mean(axis=0), 0, atol=1e-9)
+        np.testing.assert_allclose(scaled_train.std(axis=0), 1, atol=1e-9)
+        # The test split is transformed with the training mean/std, not its own.
+        np.testing.assert_allclose(scaled_test, (X_test - mean) / std)
+
+    def test_constant_column_does_not_divide_by_zero(self):
+        train = np.column_stack([np.ones(10), np.arange(10.0)])
+        scaled_train, _, _ = standardize(train, train.copy())
+        self.assertTrue(np.all(np.isfinite(scaled_train)))
+
+    def test_summary_counts_both_classes(self):
+        self.assertIn("100 genuine / 100 forged", summary(self.X, self.y))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Related Issue

Closes: #1770

- [x] Contributor (GSSoC)

---

## Description

Issue #1770 asks for a fake-currency model using **logistic regression written without
importing it from a library**. That class already exists in
`Fake_Currency_Detetction_with_logistic_regression/model.py` (added in #2113), so rather
than duplicate it in a new folder, this PR finishes the job inside the existing project.

### The problem

The from-scratch `LogisticRegression` was only ever demonstrated on **synthetic blobs**:

```python
X, y = make_classification(n_samples=500, n_features=2, ...)   # not currency data
```

So nothing in `model.py` actually touched banknotes, and the only path to real data was
`pipeline.ipynb`, which needs Kaggle credentials — you could not reproduce a currency result
by running anything in the folder.

### What this PR does

1. **`banknote_data.py`** — downloads and caches the UCI banknote authentication dataset
   (1,372 notes; variance, skewness, kurtosis, entropy from a wavelet transform), with a
   mirror fallback and **no credentials needed**. The stratified split and z-score scaling
   are written with NumPy, keeping the pipeline dependency-light and in the spirit of the
   from-scratch model.
2. **`model.py` now trains on that real data**, scales using training statistics only so
   nothing leaks from the test split, and reports held-out accuracy with a breakdown of false
   positives and missed forgeries.
3. **Fixes the loss calculation.** It added epsilon *inside* the log:
   `-mean(y·log(p + ε) + (1-y)·log(1-p + ε))`. Once the sigmoid saturates, `log(1 + ε)` is
   slightly **positive**, so the reported cross-entropy dipped below zero — visible as
   `Loss : -0.000000` during training. Clipping the probabilities instead keeps it correct:
   cross-entropy is never negative.
4. **15 offline unit tests** and a **`requirements.txt`**.

### Result

```text
Dataset: 1372 banknotes, 4 features (762 genuine / 610 forged)
Features: variance, skewness, kurtosis, entropy

Epoch : 1000 Loss : 0.080568
Training Complete!

Test accuracy : 97.45%  (274 held-out notes)
Genuine : 146 correct, 6 flagged as forged
Forged  : 121 caught,  1 missed
```

Only **1 forged note out of 122 was missed**, which is the error that matters here — a false
negative means a counterfeit passes as genuine.

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

## How Has This Been Tested?

**1. Ran `python model.py` end to end** — the output above is that real run, not an estimate.

**2. 15 unit tests, fully offline** (no download, no credentials):

```text
Ran 15 tests in 0.021s

OK
```

They test the maths rather than just the happy path:

* the sigmoid stays within `[0, 1]` even for extreme inputs, and a zero logit gives exactly 0.5
* the **analytic gradient is checked against a finite-difference estimate** (`atol=1e-5`)
* separable data is learned to >99% accuracy, and the loss decreases
* the loss stays finite **and never negative** — this is the regression test for the fix above
* the stratified split preserves class balance, has no train/test overlap, and is reproducible
* the scaler uses training statistics only, and a constant column does not divide by zero

**3. Nothing unwanted committed** — the cached dataset lands in `data/`, which the repo's
existing `*.csv` rule already ignores.

---

## Checklist

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective and that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules. *(n/a)*

---

### Notes for reviewers

* Kept inside the existing folder rather than creating a new one, since the issue's request
  is already partly implemented there.
* `app.py` and `pipeline.ipynb` are untouched — the Streamlit dashboard and the kagglehub
  route still work exactly as before. This only adds a credential-free path to real data.
* The one change to existing logic is the loss clipping, which is a correctness fix with a
  test attached.
* Suggested labels: `type:feature`, `level:intermediate`, `gssoc:approved`.
