### PR TITLE
feat: Add automated PR quality checks for Python and notebooks (#1765)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,33 @@
+# PEP8 configuration for ML-CaPsule.
+#
+# Only files changed by a pull request are linted (see
+# .github/workflows/pr_quality_check.yml), so pre-existing style in the rest of
+# the repository never blocks a contribution.
+
+[flake8]
+max-line-length = 120
+
+exclude =
+    .git,
+    __pycache__,
+    .ipynb_checkpoints,
+    node_modules,
+    venv,
+    .venv,
+    env,
+    build,
+    dist,
+    *.egg-info
+
+# E203  whitespace before ':'      - disagrees with black's slicing style
+# W503  line break before binary operator - superseded by W504, PEP8 now prefers it
+# E266  too many leading '#'       - block comments like ### are common in notebooks
+extend-ignore = E203, W503, E266
+
+# Notebook exports and demo scripts often keep unused imports for clarity.
+per-file-ignores =
+    __init__.py: F401
+
+max-complexity = 15
+count = True
+statistics = True

--- a/.github/scripts/check_notebooks.py
+++ b/.github/scripts/check_notebooks.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Static quality checks for Jupyter notebooks.
+
+This complements `notebook_health_check.py` rather than repeating it: that
+script *executes* notebooks to see whether they still run, while this one reads
+the file and looks for problems that are visible without running anything.
+
+Checks performed
+----------------
+errors (fail the job)
+    * the file is not valid notebook JSON, or has no ``cells`` list
+    * a code cell has a committed error output (a traceback was saved)
+
+warnings (reported, do not fail)
+    * the notebook contains no code cells at all
+    * a source line embeds an absolute local path such as /Users/<name>/...,
+      which will not exist on anyone else's machine
+    * the notebook is unusually large, which normally means huge embedded
+      outputs that bloat every future clone
+
+Usage
+-----
+    python .github/scripts/check_notebooks.py                 # scan everything
+    python .github/scripts/check_notebooks.py --changed-files a.ipynb b.ipynb
+    CHANGED_FILES="a.ipynb b.ipynb" python .github/scripts/check_notebooks.py
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import uuid
+from pathlib import Path
+
+# Absolute paths that only exist on the author's machine.
+LOCAL_PATH_PATTERNS = (
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\", re.IGNORECASE),
+    re.compile(r"[A-Za-z]:\\Users\\", re.IGNORECASE),
+)
+
+# Paths that are fine to reference even though they look absolute.
+LOCAL_PATH_ALLOWLIST = ("/home/user/", "/Users/runner/")
+
+LARGE_NOTEBOOK_MB = 5.0
+
+
+def emit(level, message):
+    """Print a message, as a GitHub annotation when running in Actions."""
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        print(f"::{level}::{message}")
+    else:
+        print(f"{level.upper()}: {message}")
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Statically validate notebooks.")
+    parser.add_argument("--root-dir", default=".", help="Repository root to scan.")
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=None,
+        help="Restrict the scan to these files.",
+    )
+    return parser.parse_args(argv)
+
+
+def normalize_changed_files(entries):
+    """Split whitespace or newline separated paths into a flat list."""
+    paths = []
+    for entry in entries or []:
+        if not entry:
+            continue
+        paths.extend(part for part in re.split(r"\s+", entry.strip()) if part)
+    return paths
+
+
+def find_notebooks(root_dir=".", changed_files=None):
+    """Return the notebooks to check, preferring an explicit changed-file list."""
+    root = Path(root_dir).resolve()
+    entries = normalize_changed_files(changed_files)
+
+    from_env = os.getenv("CHANGED_FILES", "")
+    if from_env and "No changed files detected" not in from_env:
+        entries.extend(normalize_changed_files([from_env]))
+
+    if entries:
+        notebooks = []
+        for entry in entries:
+            candidate = Path(entry)
+            if not candidate.is_absolute():
+                candidate = (root / candidate).resolve()
+            if (
+                candidate.is_file()
+                and candidate.suffix.lower() == ".ipynb"
+                and ".ipynb_checkpoints" not in str(candidate)
+            ):
+                notebooks.append(candidate)
+        return sorted(dict.fromkeys(notebooks))
+
+    return sorted(
+        path
+        for path in root.rglob("*.ipynb")
+        if ".ipynb_checkpoints" not in str(path)
+    )
+
+
+def cell_source(cell):
+    """Return a cell's source as one string, whatever shape it is stored in."""
+    source = cell.get("source", [])
+    if isinstance(source, list):
+        return "".join(source)
+    return source if isinstance(source, str) else ""
+
+
+def find_local_paths(text):
+    """Return absolute machine-specific paths referenced in ``text``."""
+    hits = []
+    for pattern in LOCAL_PATH_PATTERNS:
+        for match in pattern.findall(text):
+            if not any(match.startswith(allowed) for allowed in LOCAL_PATH_ALLOWLIST):
+                hits.append(match)
+    return hits
+
+
+def check_notebook(path):
+    """Return ``(errors, warnings)`` for a single notebook."""
+    errors, warnings = [], []
+    name = Path(path).name
+
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"{name}: not valid notebook JSON ({exc})"], []
+    except OSError as exc:
+        return [f"{name}: could not be read ({exc})"], []
+
+    cells = payload.get("cells")
+    if not isinstance(cells, list):
+        return [f"{name}: no 'cells' list - this is not a valid notebook"], []
+    if not cells:
+        return [f"{name}: contains no cells"], []
+
+    size_mb = Path(path).stat().st_size / (1024 * 1024)
+    if size_mb > LARGE_NOTEBOOK_MB:
+        warnings.append(
+            f"{name}: {size_mb:.1f} MB is large; consider clearing bulky outputs "
+            f"before committing"
+        )
+
+    code_cells = 0
+    for index, cell in enumerate(cells, start=1):
+        if cell.get("cell_type") == "code":
+            code_cells += 1
+            for output in cell.get("outputs") or []:
+                if output.get("output_type") == "error":
+                    ename = output.get("ename", "Error")
+                    errors.append(
+                        f"{name}: cell {index} has a committed {ename} traceback - "
+                        f"re-run the cell and save a clean output"
+                    )
+
+        for local_path in find_local_paths(cell_source(cell)):
+            warnings.append(
+                f"{name}: cell {index} references the local path '{local_path}...' "
+                f"which will not exist for other users"
+            )
+
+    if code_cells == 0:
+        warnings.append(f"{name}: contains no code cells")
+
+    return errors, warnings
+
+
+def build_report(results):
+    """Render a Markdown summary of every notebook that was checked."""
+    total_errors = sum(len(item["errors"]) for item in results)
+    total_warnings = sum(len(item["warnings"]) for item in results)
+
+    lines = ["### 📓 Notebook Quality Check"]
+    if not results:
+        lines.append("\nNo notebooks were changed. Nothing to check. 🎉")
+        return "\n".join(lines)
+
+    lines.append(f"\n**Notebooks checked:** {len(results)}")
+    lines.append(f"**Errors:** {total_errors} · **Warnings:** {total_warnings}\n")
+
+    if total_errors:
+        lines.append("#### ❌ Errors")
+        for item in results:
+            lines.extend(f"- {message}" for message in item["errors"])
+    if total_warnings:
+        lines.append("\n#### ⚠️ Warnings")
+        for item in results:
+            lines.extend(f"- {message}" for message in item["warnings"])
+    if not total_errors and not total_warnings:
+        lines.append("All changed notebooks look clean. 🎉")
+
+    return "\n".join(lines)
+
+
+def write_github_output(report):
+    """Expose the report to later workflow steps."""
+    target = os.environ.get("GITHUB_OUTPUT")
+    if not target:
+        return
+    delimiter = str(uuid.uuid4())
+    with open(target, "a", encoding="utf-8") as handle:
+        handle.write(f"report<<{delimiter}\n{report}\n{delimiter}\n")
+
+
+def run(root_dir=".", changed_files=None):
+    """Check the selected notebooks and return the number of hard errors."""
+    notebooks = find_notebooks(root_dir, changed_files)
+    if not notebooks:
+        print("No notebooks to check.")
+        write_github_output(build_report([]))
+        return 0
+
+    print(f"Checking {len(notebooks)} notebook(s)...")
+    results = []
+    for notebook in notebooks:
+        errors, warnings = check_notebook(notebook)
+        results.append({"path": str(notebook), "errors": errors, "warnings": warnings})
+        for message in errors:
+            emit("error", message)
+        for message in warnings:
+            emit("warning", message)
+        if not errors and not warnings:
+            print(f"  ok  {Path(notebook).name}")
+
+    report = build_report(results)
+    write_github_output(report)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+    else:
+        print("\n" + report)
+
+    return sum(len(item["errors"]) for item in results)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    return 1 if run(args.root_dir, args.changed_files) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/pr_quality_check.yml
+++ b/.github/workflows/pr_quality_check.yml
@@ -1,0 +1,134 @@
+name: PR Quality Check
+
+# Runs on every pull request, but only ever looks at the files that pull
+# request changed - pre-existing issues elsewhere in the repository never block
+# a contribution.
+on:
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+# Read-only: this workflow checks out pull request code, so it must never hold
+# a writable token. Results are published as annotations and a job summary,
+# which work for pull requests from forks too (a fork's GITHUB_TOKEN is
+# read-only, so a bot comment would simply fail for most contributors).
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Syntax, PEP8 and notebooks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install linters
+        run: python -m pip install --quiet --upgrade pip flake8
+
+      - name: Collect changed files
+        id: changed
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="origin/${{ github.base_ref }}"
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            BASE="HEAD^"
+          fi
+          git fetch origin "${{ github.base_ref }}" --depth=1 || true
+
+          # Only Added/Copied/Modified files: a file deleted by this PR cannot be linted.
+          git diff --name-only --diff-filter=ACM "$BASE"...HEAD > changed.txt \
+            || git diff --name-only --diff-filter=ACM "$BASE" HEAD > changed.txt \
+            || true
+
+          grep -E '\.py$'    changed.txt > changed_py.txt    || true
+          grep -E '\.ipynb$' changed.txt > changed_nb.txt    || true
+
+          echo "py_count=$(wc -l < changed_py.txt | tr -d ' ')"    >> "$GITHUB_OUTPUT"
+          echo "nb_count=$(wc -l < changed_nb.txt | tr -d ' ')"    >> "$GITHUB_OUTPUT"
+          {
+            echo "### 🔍 PR Quality Check"
+            echo ""
+            echo "Changed Python files: $(wc -l < changed_py.txt | tr -d ' ') ·"\
+                 "Changed notebooks: $(wc -l < changed_nb.txt | tr -d ' ')"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A file that will not even parse is always a hard failure.
+      - name: Python syntax (py_compile)
+        if: steps.changed.outputs.py_count != '0'
+        shell: bash
+        run: |
+          set -uo pipefail
+          status=0
+          while IFS= read -r file; do
+            [ -f "$file" ] || continue
+            if ! output=$(python -m py_compile "$file" 2>&1); then
+              echo "::error file=$file::Syntax error - $(echo "$output" | tail -1)"
+              status=1
+            fi
+          done < changed_py.txt
+          if [ "$status" -eq 0 ]; then
+            echo "✅ All changed Python files parse cleanly." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ Some changed Python files have syntax errors." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$status"
+
+      # Style is advisory, matching how the existing Notebook Health Check
+      # behaves, so a first-time contributor is guided rather than blocked.
+      - name: PEP8 style (flake8)
+        if: steps.changed.outputs.py_count != '0'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -uo pipefail
+          mapfile -t files < changed_py.txt
+          existing=()
+          for file in "${files[@]}"; do
+            [ -f "$file" ] && existing+=("$file")
+          done
+          if [ ${#existing[@]} -eq 0 ]; then
+            echo "No Python files to lint." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # GitHub renders this format as inline annotations on the diff.
+          flake8 "${existing[@]}" \
+            --format='::warning file=%(path)s,line=%(row)d,col=%(col)d::%(code)s %(text)s' \
+            || true
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### 🐍 PEP8 (flake8, max line length 120)" >> "$GITHUB_STEP_SUMMARY"
+          if flake8 "${existing[@]}" > flake8.txt 2>&1; then
+            echo "✅ No style issues in the changed files." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo ""
+              echo '```'
+              head -50 flake8.txt
+              echo '```'
+              echo ""
+              echo "Style issues are advisory and do not block this PR."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Notebook quality
+        if: steps.changed.outputs.nb_count != '0'
+        shell: bash
+        run: |
+          set -uo pipefail
+          mapfile -t notebooks < changed_nb.txt
+          python .github/scripts/check_notebooks.py --changed-files "${notebooks[@]}"
+
+      - name: Nothing to check
+        if: steps.changed.outputs.py_count == '0' && steps.changed.outputs.nb_count == '0'
+        run: echo "No Python files or notebooks changed - nothing to check. 🎉"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,60 @@ We want your work to be readable by others; therefore, we encourage you to note 
 
 ---
 
+## 🤖 Automated Quality Checks (CI)
+
+Every pull request targeting `main` / `master` is checked automatically by **GitHub Actions**
+(`.github/workflows/pr_quality_check.yml`). The checks look **only at the files your PR
+changed**, so pre-existing issues elsewhere in the repository never block your contribution.
+
+### What gets checked
+
+**🐍 Python files (`.py`)**
+
+| Check | Tool | Catches | Blocks the PR? |
+|-------|------|---------|:--------------:|
+| Syntax errors | `py_compile` | Invalid Python that will not even import | ✅ Yes |
+| PEP8 style | `flake8` | Indentation, spacing, naming, line length (max 120) | ❌ Advisory |
+
+**📓 Notebooks (`.ipynb`)** — `.github/scripts/check_notebooks.py`
+
+| Check | Catches | Blocks the PR? |
+|-------|---------|:--------------:|
+| Valid notebook JSON | Corrupt or truncated files | ✅ Yes |
+| Committed error outputs | A saved traceback, meaning the notebook was committed while failing | ✅ Yes |
+| Local absolute paths | `/Users/you/...` or `C:\Users\you\...`, which will not exist for anyone else | ❌ Advisory |
+| Large notebooks | Bulky embedded outputs that bloat every clone | ❌ Advisory |
+| No code cells | A notebook that contains only prose | ❌ Advisory |
+
+This is separate from the existing **Notebook Health Check**, which *executes* changed
+notebooks. These checks read the file without running it.
+
+### Where results appear
+
+Findings show up as **inline annotations on your diff** and in the **job summary** on the
+Actions tab. Results are not posted as a PR comment, because a pull request opened from a
+fork gets a read-only token, so a bot comment would fail for most contributors.
+
+### Running the checks locally
+
+```bash
+pip install flake8
+
+flake8 path/to/your_file.py                       # PEP8, uses the repo's .flake8
+python -m py_compile path/to/your_file.py         # syntax
+python .github/scripts/check_notebooks.py --changed-files your_notebook.ipynb
+```
+
+To check everything you changed against `master`:
+
+```bash
+git diff --name-only --diff-filter=ACM master...HEAD | grep '\.py$'    | xargs -r flake8
+git diff --name-only --diff-filter=ACM master...HEAD | grep '\.ipynb$' \
+  | xargs -r python .github/scripts/check_notebooks.py --changed-files
+```
+
+---
+
 ## 🔑Guidelines
 
 1. Welcome to this repository, if you are here as an open source program participant/contributor.

--- a/tests/test_check_notebooks.py
+++ b/tests/test_check_notebooks.py
@@ -1,0 +1,199 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "check_notebooks.py"
+SPEC = importlib.util.spec_from_file_location("check_notebooks", SCRIPT_PATH)
+check_notebooks = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(check_notebooks)
+
+
+def notebook(cells, **extra):
+    """Build a minimal but valid notebook payload."""
+    payload = {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    payload.update(extra)
+    return payload
+
+
+def code_cell(source="print('hi')", outputs=None):
+    return {
+        "cell_type": "code",
+        "source": source if isinstance(source, list) else [source],
+        "outputs": outputs or [],
+        "execution_count": 1,
+        "metadata": {},
+    }
+
+
+def write(payload, directory, name="demo.ipynb"):
+    path = Path(directory) / name
+    if isinstance(payload, str):
+        path.write_text(payload, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class CleanNotebookTests(unittest.TestCase):
+    def test_a_healthy_notebook_reports_nothing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook([code_cell()]), directory)
+            errors, warnings = check_notebooks.check_notebook(path)
+            self.assertEqual(errors, [])
+            self.assertEqual(warnings, [])
+
+
+class ErrorTests(unittest.TestCase):
+    def test_invalid_json_is_an_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = write("{not json at all", directory)
+            errors, _ = check_notebooks.check_notebook(path)
+            self.assertEqual(len(errors), 1)
+            self.assertIn("not valid notebook JSON", errors[0])
+
+    def test_missing_cells_list_is_an_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = write({"metadata": {}, "nbformat": 4}, directory)
+            errors, _ = check_notebooks.check_notebook(path)
+            self.assertIn("no 'cells' list", errors[0])
+
+    def test_empty_notebook_is_an_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook([]), directory)
+            errors, _ = check_notebooks.check_notebook(path)
+            self.assertIn("contains no cells", errors[0])
+
+    def test_committed_traceback_is_an_error(self):
+        error_output = {
+            "output_type": "error",
+            "ename": "ValueError",
+            "evalue": "bad input",
+            "traceback": ["Traceback..."],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook([code_cell(outputs=[error_output])]), directory)
+            errors, _ = check_notebooks.check_notebook(path)
+            self.assertEqual(len(errors), 1)
+            self.assertIn("ValueError", errors[0])
+            self.assertIn("cell 1", errors[0])
+
+    def test_a_normal_stream_output_is_not_an_error(self):
+        stream = {"output_type": "stream", "name": "stdout", "text": ["hi\n"]}
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook([code_cell(outputs=[stream])]), directory)
+            errors, _ = check_notebooks.check_notebook(path)
+            self.assertEqual(errors, [])
+
+
+class WarningTests(unittest.TestCase):
+    def test_local_mac_path_is_flagged(self):
+        cell = code_cell("data = open('/Users/someone/data/train.csv')")
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook([cell]), directory)
+            _, warnings = check_notebooks.check_notebook(path)
+            self.assertEqual(len(warnings), 1)
+            self.assertIn("local path", warnings[0])
+
+    def test_local_linux_and_windows_paths_are_flagged(self):
+        cells = [
+            code_cell("p = '/home/anna/datasets/x.csv'"),
+            code_cell("p = r'C:\\Users\\Anna\\data.csv'"),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook(cells), directory)
+            _, warnings = check_notebooks.check_notebook(path)
+            self.assertEqual(len(warnings), 2)
+
+    def test_ci_and_colab_paths_are_allowed(self):
+        cells = [
+            code_cell("p = '/home/user/app/data.csv'"),
+            code_cell("p = '/Users/runner/work/repo/file.csv'"),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook(cells), directory)
+            _, warnings = check_notebooks.check_notebook(path)
+            self.assertEqual(warnings, [])
+
+    def test_notebook_without_code_cells_is_flagged(self):
+        markdown = {"cell_type": "markdown", "source": ["# Title"], "metadata": {}}
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook([markdown]), directory)
+            _, warnings = check_notebooks.check_notebook(path)
+            self.assertIn("no code cells", warnings[0])
+
+    def test_string_source_is_handled(self):
+        cell = {"cell_type": "code", "source": "x = 1", "outputs": [], "metadata": {}}
+        with tempfile.TemporaryDirectory() as directory:
+            path = write(notebook([cell]), directory)
+            errors, warnings = check_notebooks.check_notebook(path)
+            self.assertEqual((errors, warnings), ([], []))
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_changed_files_filter_to_notebooks(self):
+        with tempfile.TemporaryDirectory() as directory:
+            write(notebook([code_cell()]), directory, "a.ipynb")
+            Path(directory, "script.py").write_text("x = 1", encoding="utf-8")
+            found = check_notebooks.find_notebooks(
+                directory, ["a.ipynb", "script.py", "missing.ipynb"]
+            )
+            self.assertEqual([p.name for p in found], ["a.ipynb"])
+
+    def test_checkpoints_are_ignored_in_a_full_scan(self):
+        with tempfile.TemporaryDirectory() as directory:
+            write(notebook([code_cell()]), directory, "real.ipynb")
+            checkpoints = Path(directory, ".ipynb_checkpoints")
+            checkpoints.mkdir()
+            write(notebook([code_cell()]), checkpoints, "real-checkpoint.ipynb")
+            found = check_notebooks.find_notebooks(directory)
+            self.assertEqual([p.name for p in found], ["real.ipynb"])
+
+    def test_whitespace_separated_paths_are_split(self):
+        self.assertEqual(
+            check_notebooks.normalize_changed_files(["a.ipynb b.ipynb\nc.ipynb"]),
+            ["a.ipynb", "b.ipynb", "c.ipynb"],
+        )
+
+
+class ReportTests(unittest.TestCase):
+    def test_report_counts_errors_and_warnings(self):
+        report = check_notebooks.build_report(
+            [{"path": "a.ipynb", "errors": ["a.ipynb: boom"], "warnings": ["a.ipynb: hmm"]}]
+        )
+        self.assertIn("**Errors:** 1", report)
+        self.assertIn("a.ipynb: boom", report)
+        self.assertIn("a.ipynb: hmm", report)
+
+    def test_report_with_no_notebooks(self):
+        self.assertIn("No notebooks were changed", check_notebooks.build_report([]))
+
+    def test_clean_report_says_so(self):
+        report = check_notebooks.build_report(
+            [{"path": "a.ipynb", "errors": [], "warnings": []}]
+        )
+        self.assertIn("look clean", report)
+
+
+class ExitCodeTests(unittest.TestCase):
+    def test_errors_exit_non_zero(self):
+        with tempfile.TemporaryDirectory() as directory:
+            write("{broken", directory, "bad.ipynb")
+            self.assertEqual(check_notebooks.main(["--root-dir", directory]), 1)
+
+    def test_clean_run_exits_zero(self):
+        with tempfile.TemporaryDirectory() as directory:
+            write(notebook([code_cell()]), directory, "ok.ipynb")
+            self.assertEqual(check_notebooks.main(["--root-dir", directory]), 0)
+
+    def test_warnings_alone_do_not_fail(self):
+        markdown = {"cell_type": "markdown", "source": ["# Title"], "metadata": {}}
+        with tempfile.TemporaryDirectory() as directory:
+            write(notebook([markdown]), directory, "docs.ipynb")
+            self.assertEqual(check_notebooks.main(["--root-dir", directory]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Related Issue

Closes: #1765

- [x] Contributor (GSSoC)

---

## Description

Adds the automated PR quality checks described in the issue: every pull request targeting
`main` / `master` is checked by GitHub Actions, and **only the files that PR changed are
inspected**, so pre-existing issues elsewhere never block a contribution.

### Files added

| File | Purpose |
|---|---|
| `.github/workflows/pr_quality_check.yml` | The workflow |
| `.github/scripts/check_notebooks.py` | Static notebook validator |
| `.flake8` | PEP8 configuration (max line length 120) |
| `tests/test_check_notebooks.py` | 20 unit tests for the validator |
| `CONTRIBUTING.md` | Documentation (the issue asked for this to be merged into CONTRIBUTING rather than a separate `CONTRIBUTING_CI.md`) |

### What gets checked

**🐍 Python (`.py`)**

| Check | Tool | Catches | Blocks? |
|---|---|---|:--:|
| Syntax errors | `py_compile` | Invalid Python that will not import | ✅ Yes |
| PEP8 style | `flake8` | Indentation, spacing, naming, line length (120) | ❌ Advisory |

**📓 Notebooks (`.ipynb`)** — `check_notebooks.py`

| Check | Catches | Blocks? |
|---|---|:--:|
| Valid notebook JSON | Corrupt or truncated files | ✅ Yes |
| Committed error outputs | A saved traceback — the notebook was committed while failing | ✅ Yes |
| Local absolute paths | `/Users/you/...`, `C:\Users\you\...` | ❌ Advisory |
| Large notebooks | Bulky embedded outputs that bloat every clone | ❌ Advisory |
| No code cells | Prose-only notebooks | ❌ Advisory |

### Two design decisions worth reviewing

**1. It complements the existing Notebook Health Check rather than duplicating it.**
`notebook_health_check.py` *executes* changed notebooks. This one *reads* them and checks
things that are visible without running anything, so the two do not overlap.

**2. Results are annotations + a job summary, not a bot comment.**
The issue describes a PR comment, and I started there, but a comment cannot work for the
contributors who need it: this workflow checks out PR code, so it must keep a **read-only
token**, and GitHub gives a fork's `GITHUB_TOKEN` read-only permissions on `pull_request`
anyway — the comment step would simply fail on nearly every GSSoC PR. Using
`pull_request_target` would grant write access to a workflow that checks out untrusted code,
which is the classic "pwn request" vulnerability, so I did not do that.

Inline annotations appear directly on the diff, which is arguably better placed than a
comment. If you would like comments as well, the safe pattern is a follow-up `workflow_run`
workflow — happy to add that separately.

Also, style is advisory rather than blocking, matching how the existing Notebook Health Check
behaves (`continue-on-error`), so a first-time contributor is guided rather than rejected.
Syntax errors and broken notebooks still fail.

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

## How Has This Been Tested?

**1. The validator was run against the whole repository** — 464 real notebooks:

```text
Checking 464 notebook(s)...
hard errors:  22
warnings:     61
   43  local absolute paths (e.g. /Users/murielkosaka/..., C:\Users\...)
   14  oversized notebooks (largest: stock-market-prediction.ipynb at 10.7 MB)
    4  no code cells
```

Example of a real hard error it found:

```text
ERROR: AI-Language-Learning-Assistant.ipynb: cell 10 has a committed
       KeyboardInterrupt traceback - re-run the cell and save a clean output
```

**None of those 83 findings will block anybody**, because CI only inspects the files a PR
touches. They are listed here purely as evidence the checks fire on real content.

**2. 20 unit tests, all passing**, following the pattern of the existing
`tests/test_notebook_health_check.py`:

```text
Ran 20 tests in 0.010s
OK
```

The full suite (existing + new) is green: `Ran 22 tests ... OK`.

They cover valid/invalid JSON, missing `cells`, empty notebooks, committed tracebacks,
non-error outputs, Mac/Linux/Windows local paths, the CI and Colab path allowlist, prose-only
notebooks, string vs list cell sources, changed-file filtering, `.ipynb_checkpoints`
exclusion, report rendering, and exit codes (errors exit 1, warnings alone exit 0).

**3. The workflow steps were simulated locally** on purpose-built sample files:

```console
=== py_compile (hard gate) ===
  FAIL  broken.py -> SyntaxError: invalid syntax
  PASS  messy.py
  PASS  good.py

=== flake8 (advisory), using the repo .flake8 ===
messy.py:1:1: F401 'os' imported but unused
messy.py:2:2: E225 missing whitespace around operator
messy.py:3:1: E302 expected 2 blank lines, found 0
good.py -> clean

=== annotation format emitted to GitHub ===
::warning file=messy.py,line=1,col=1::F401 'os' imported but unused
```

**4. The workflow YAML parses**, with the expected triggers, `permissions: {contents: read}`
and 8 steps.

**5. The new Python files pass their own linter** — `flake8` on `check_notebooks.py` and the
test file reports zero issues under the new `.flake8`.

---

## Checklist

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules. *(n/a)*

---

### Notes for reviewers

* No existing workflow is modified. `notebook-health.yml` and the rest are untouched.
* The workflow will not run on this PR until a maintainer approves the run, since it is from
  a fork — the evidence above is from running each step locally.
* If the advisory/blocking split is not what you want, it is a one-line change per step
  (`continue-on-error`), so say the word and I will adjust.
* Suggested labels: `type:devops`, `level:intermediate`, `gssoc:approved`.
