### PR TITLE
feat: Add transformer sentiment analysis to the IMDb project (#1671)

### DIFF
--- a/Sentiment-Analysis-on-IMDb-reviews/README.md
+++ b/Sentiment-Analysis-on-IMDb-reviews/README.md
@@ -39,6 +39,53 @@ The original implementation is provided as a **Jupyter Notebook**, which fetches
 2. Vader
 3. Flair
 4. text2emotion
+5. Transformer — DistilBERT fine-tuned on SST-2 (Hugging Face)
+
+<br>
+
+## Traditional vs Transformer 🤖
+
+TextBlob and VADER are **lexicon based**: every word carries a fixed score and the scores are
+added up. A transformer reads the sentence as a whole, so word order, negation and sarcasm
+change the answer.
+
+`compare_models.py` runs all three over the same labelled reviews from the IMDb test split:
+
+```bash
+python compare_models.py --sample 200
+```
+
+| Model | Accuracy | Time for 200 reviews |
+|-------|:--------:|:--------------------:|
+| TextBlob | 62.0% | 0.2 s |
+| VADER | 69.5% | 0.2 s |
+| **DistilBERT (SST-2)** | **86.5%** | 36.5 s |
+
+*200 reviews from the IMDb test split, seed 42.*
+
+The accuracy comes at a cost: the transformer is roughly **180× slower** and downloads about
+250 MB the first time. For short, plainly worded text the lexicon models are often enough.
+
+### Where the lexicon models break
+
+Three real reviews from that run, and what each model said:
+
+**Sarcasm** — *"This movie spends most of its time preaching that it is the script that makes
+the movie, but apparently there was no script when they shot this waste of time!"*
+True: **Negative**. TextBlob: Positive · VADER: Positive · DistilBERT: **Negative**
+
+**A positive review about a sad subject** — *"This is a really sad, and touching movie! It
+deals with the subject of child abuse."*
+True: **Positive**. TextBlob: Negative · VADER: Positive · DistilBERT: **Positive**
+TextBlob sees "sad" and "abuse" and stops there.
+
+**Negation** — *"Don't pay any attention to the rave reviews of this film here. It is the
+worst Van Damme film..."*
+True: **Negative**. TextBlob: Negative · VADER: Positive · DistilBERT: **Negative**
+VADER scores "rave" positively and misses that the sentence rejects it.
+
+> DistilBERT SST-2 is a binary model. When its confidence falls below 0.6 the app reports
+> **Neutral**, so its output matches the labels the other analysers return.
 
 <br>
 

--- a/Sentiment-Analysis-on-IMDb-reviews/app.py
+++ b/Sentiment-Analysis-on-IMDb-reviews/app.py
@@ -3,7 +3,7 @@ import pandas as pd
 import plotly.express as px
 
 from api import get_movies, get_reviews
-from sentiment import textblob_sentiment, vader_sentiment
+from sentiment import ANALYSERS
 
 st.set_page_config(
     page_title="IMDb Sentiment Analysis",
@@ -17,8 +17,14 @@ movie_name = st.text_input("Enter Movie Name")
 
 model = st.selectbox(
     "Select Sentiment Model",
-    ["TextBlob", "VADER"]
+    list(ANALYSERS)
 )
+
+if model.startswith("Transformer"):
+    st.caption(
+        "The transformer downloads about 250 MB the first time it runs, "
+        "then reads each review in full."
+    )
 
 if st.button("Analyze"):
 
@@ -47,15 +53,11 @@ if st.button("Analyze"):
             else:
 
                 sentiments = []
+                analyse = ANALYSERS[model]
 
-                for review in reviews:
-
-                    if model == "TextBlob":
-                        sentiment = textblob_sentiment(review)
-                    else:
-                        sentiment = vader_sentiment(review)
-
-                    sentiments.append(sentiment)
+                with st.spinner(f"Analysing {len(reviews)} reviews with {model}..."):
+                    for review in reviews:
+                        sentiments.append(analyse(review))
 
                 df = pd.DataFrame({
                     "Review": reviews,

--- a/Sentiment-Analysis-on-IMDb-reviews/compare_models.py
+++ b/Sentiment-Analysis-on-IMDb-reviews/compare_models.py
@@ -1,0 +1,85 @@
+"""Compare the sentiment analysers on labelled IMDb reviews.
+
+Downloads a sample of the IMDb test split, runs every analyser in sentiment.py
+over the same reviews and reports how often each agrees with the true label.
+
+    python compare_models.py --sample 200
+"""
+
+import argparse
+import time
+
+from sentiment import ANALYSERS
+
+LABELS = {0: "Negative", 1: "Positive"}
+IMDB_DATASET = "stanfordnlp/imdb"
+
+
+def load_reviews(sample_size, seed=42):
+    from datasets import load_dataset
+
+    dataset = load_dataset(IMDB_DATASET, split="test").shuffle(seed=seed)
+    rows = dataset.select(range(sample_size))
+    return list(rows["text"]), [LABELS[label] for label in rows["label"]]
+
+
+def evaluate(name, analyse, reviews, truths):
+    predictions = []
+    started = time.perf_counter()
+    for review in reviews:
+        predictions.append(analyse(review))
+    elapsed = time.perf_counter() - started
+
+    correct = sum(p == t for p, t in zip(predictions, truths))
+    neutral = predictions.count("Neutral")
+    return {
+        "name": name,
+        "accuracy": correct / len(truths),
+        "neutral": neutral,
+        "seconds": elapsed,
+        "predictions": predictions,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sample", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--examples", type=int, default=3)
+    args = parser.parse_args()
+
+    reviews, truths = load_reviews(args.sample, args.seed)
+    print(f"{len(reviews)} IMDb test reviews "
+          f"({truths.count('Positive')} positive / {truths.count('Negative')} negative)\n")
+
+    results = [evaluate(name, fn, reviews, truths) for name, fn in ANALYSERS.items()]
+
+    print(f"{'model':<26} {'accuracy':>9} {'neutral':>9} {'seconds':>9}")
+    print("-" * 56)
+    for result in results:
+        print(f"{result['name']:<26} {result['accuracy']:>8.1%} "
+              f"{result['neutral']:>9} {result['seconds']:>9.1f}")
+
+    baseline = results[-1]
+    others = results[:-1]
+    print(f"\nReviews {baseline['name']} gets right and the others do not:\n")
+
+    shown = 0
+    for index, truth in enumerate(truths):
+        if shown >= args.examples:
+            break
+        if baseline["predictions"][index] != truth:
+            continue
+        if all(other["predictions"][index] == truth for other in others):
+            continue
+
+        snippet = " ".join(reviews[index].split())[:220]
+        print(f"  true: {truth}")
+        for result in results:
+            print(f"    {result['name']:<26} {result['predictions'][index]}")
+        print(f"    \"{snippet}...\"\n")
+        shown += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/Sentiment-Analysis-on-IMDb-reviews/requirements.txt
+++ b/Sentiment-Analysis-on-IMDb-reviews/requirements.txt
@@ -5,3 +5,10 @@ plotly
 textblob
 nltk
 python-dotenv
+
+# Transformer analyser
+transformers
+torch
+
+# Only needed by compare_models.py
+datasets

--- a/Sentiment-Analysis-on-IMDb-reviews/sentiment.py
+++ b/Sentiment-Analysis-on-IMDb-reviews/sentiment.py
@@ -6,6 +6,7 @@ nltk.download("vader_lexicon")
 
 vader_analyzer = SentimentIntensityAnalyzer()
 
+
 def textblob_sentiment(text):
     polarity = TextBlob(text).sentiment.polarity
 
@@ -26,3 +27,48 @@ def vader_sentiment(text):
         return "Negative"
     else:
         return "Neutral"
+
+
+TRANSFORMER_MODEL = "distilbert-base-uncased-finetuned-sst-2-english"
+NEUTRAL_THRESHOLD = 0.6
+
+_transformer_pipeline = None
+
+
+def load_transformer(model_name=TRANSFORMER_MODEL):
+    global _transformer_pipeline
+
+    if _transformer_pipeline is None:
+        from transformers import pipeline
+
+        _transformer_pipeline = pipeline(
+            "sentiment-analysis",
+            model=model_name,
+            truncation=True,
+            max_length=512,
+        )
+
+    return _transformer_pipeline
+
+
+def transformer_sentiment(text, threshold=NEUTRAL_THRESHOLD):
+    result = load_transformer()(text)[0]
+
+    # SST-2 is a binary model, so a low-confidence prediction is reported as
+    # Neutral to match the labels the other analysers return.
+    if result["score"] < threshold:
+        return "Neutral"
+
+    return "Positive" if result["label"].upper() == "POSITIVE" else "Negative"
+
+
+def transformer_sentiment_score(text):
+    result = load_transformer()(text)[0]
+    return result["label"].upper(), float(result["score"])
+
+
+ANALYSERS = {
+    "TextBlob": textblob_sentiment,
+    "VADER": vader_sentiment,
+    "Transformer (DistilBERT)": transformer_sentiment,
+}


### PR DESCRIPTION
## Related Issue

Closes: #1671

- [x] Contributor (GSSoC)

---

## Description

Adds a Hugging Face transformer alongside the existing lexicon-based analysers in the IMDb
project, and — the part that makes it useful for learners — **measures the difference on
labelled data** instead of asserting it.

### What was added

* **`sentiment.py`** — `transformer_sentiment()`, backed by DistilBERT fine-tuned on SST-2.
  The pipeline is imported and loaded lazily, so the app still starts without `transformers`
  installed and the ~250 MB download only happens if the model is actually selected.
* **`app.py`** — the analysers now live in an `ANALYSERS` dict and the Streamlit selectbox is
  built from it, replacing an `if/else` chain that had to grow with every new model.
* **`compare_models.py`** — runs every analyser over the same sample of the IMDb test split
  and reports accuracy, neutral count and runtime, then prints reviews where the transformer
  is right and the lexicon models are not.
* **`README.md`** — documents the comparison and explains *why* the results differ.

---

## Results

```bash
python compare_models.py --sample 200
```

```text
200 IMDb test reviews (96 positive / 104 negative)

model                       accuracy   neutral   seconds
--------------------------------------------------------
TextBlob                      62.0%         0       0.2
VADER                         69.5%         2       0.2
Transformer (DistilBERT)      86.5%         2      36.5
```

**+17 points over VADER, +24.5 over TextBlob** — and about **180× slower**. The README states
the cost as plainly as the gain, because for short, plainly worded text the lexicon models are
often the sensible choice.

### Why the lexicon models lose

The script prints the reviews where they disagree. Three real ones from that run:

**Sarcasm** — *"This movie spends most of its time preaching that it is the script that makes
the movie, but apparently there was no script when they shot this waste of time!"*
True **Negative** · TextBlob: Positive · VADER: Positive · **DistilBERT: Negative**

**Positive review, sad subject** — *"This is a really sad, and touching movie! It deals with
the subject of child abuse."*
True **Positive** · TextBlob: Negative · VADER: Positive · **DistilBERT: Positive**
TextBlob sees "sad" and "abuse" and stops there.

**Negation** — *"Don't pay any attention to the rave reviews of this film here. It is the
worst Van Damme film..."*
True **Negative** · TextBlob: Negative · VADER: Positive · **DistilBERT: Negative**
VADER scores "rave" positively and misses that the sentence rejects it.

That is the lesson the issue asked for: lexicon models add up per-word scores, so word order,
negation and sarcasm are invisible to them.

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

## How Has This Been Tested?

* **Ran `compare_models.py` end to end** — the table and the examples above are that run, not
  estimates. Reproducible: fixed seed, dataset pulled from `stanfordnlp/imdb`.
* **Smoke-tested all three analysers** through the shared registry on clear positive and
  negative sentences; all agree where they should.
* **`flake8 --max-line-length=120` is clean** on `sentiment.py`, `app.py` and
  `compare_models.py`. That also fixed two pre-existing warnings in files I was already
  touching (a missing blank line and two missing end-of-file newlines).
* The existing TextBlob and VADER paths are unchanged — same functions, same thresholds.

---

## Checklist

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my feature works. *(`compare_models.py` is the verification here; happy to add a unit test module if you would like one)*
- [ ] Any dependent changes have been merged and published in downstream modules. *(n/a)*

---

### Notes for reviewers

* **`torch` and `transformers` are heavy.** They are in `requirements.txt` because the feature
  needs them, but the import is inside the function, so anyone who only wants TextBlob/VADER
  can still run the app if the install fails or is skipped.
* **`datasets` is only used by `compare_models.py`**, and is marked as such in the
  requirements file.
* **SST-2 is a binary model** — it has no neutral class. Rather than silently dropping the
  neutral label the rest of the app uses, predictions under 0.6 confidence are reported as
  Neutral. The threshold is a named constant if you would prefer a different value.
* The README previously listed Flair and text2emotion as implemented, but the Streamlit app
  only wires up TextBlob and VADER. I left that as-is rather than widening this PR — worth a
  separate issue if you want the app to match the README.
* Suggested labels: `type:feature`, `level:intermediate`, `gssoc:approved`.
