### PR TITLE
docs: fix Table of Contents heading not rendering due to missing blank line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Welcome to **ML-Capsule**!!! This repository is a comprehensive collection of ma
     <img src="https://img.shields.io/github/issues-closed-raw/Niketkumardheeryan/ML-CaPsule" alt="GitHub closed issues" />
     <img src="https://img.shields.io/github/issues-pr/Niketkumardheeryan/ML-CaPsule" alt="GitHub pull requests" />
     <img src="https://img.shields.io/github/issues-pr-closed/Niketkumardheeryan/ML-CaPsule" alt="GitHub closed pull requests" />
-  </p>
+ </p>
 </div>
+
 ## 📑 Table of Contents
 
 - [📈 Why Machine Learning?](#-why-machine-learning)


### PR DESCRIPTION
PR Description: Fixed the Table of Contents heading in README.md not rendering properly — a missing blank line between the closing </div> and the heading caused it to be swallowed into the preceding HTML block.

Issue: closes #None (just a documentation quick fix )