### PR TITLE
fix: handle missing model artifacts in Air Quality Predictor

### DIFF
--- a/Air_quality_prediction/README.md
+++ b/Air_quality_prediction/README.md
@@ -20,22 +20,38 @@ A real-time Air Quality Index (AQI) prediction dashboard built with Streamlit. T
 ## 📁 Project Structure
 ```text
 ├── app.py               # Main Streamlit application script
-├── weights.pkl          # Serialized dictionary containing the PyTorch model, LightGBM model, scaler, and encoders
+├── AQI_pred.ipynb       # Trains the models and exports weights.pkl
+├── weights.pkl          # Generated model artifact (not stored in Git)
 ├── requirements.txt     # Python dependencies
 └── README.md            # Project documentation
 ```
-# ⚙️ Installation & Setup
-- Install dependencies:
+## ⚙️ Installation and setup
+
+From the repository root, enter the project directory and install the dependencies:
+
 ```bash
-pip install scikit-learn pandas numpy torch streamlit lightgbm joblib
+cd Air_quality_prediction
+python -m pip install -r requirements.txt
 ```
 
-- 💻 Usage
-Run the Streamlit application locally:
+### Generate the model artifact
+
+Trained model artifacts are not stored in Git. Start Jupyter from this directory, open `AQI_pred.ipynb`, and run all cells:
+
+```bash
+jupyter notebook AQI_pred.ipynb
+```
+
+The notebook downloads the dataset through KaggleHub, trains both models, and creates `weights.pkl`. Confirm that the file exists in `Air_quality_prediction` before starting the dashboard.
+
+### Run the dashboard
+
 ```bash
 streamlit run app.py
 ```
 The dashboard will open in your default web browser (usually at http://localhost:8501). Enter the temporal, geographic, and weather details to generate an instant AQI prediction.
+
+If `weights.pkl` is missing or invalid, the dashboard displays recovery instructions instead of terminating with an unhandled exception.
 
 ## 🧠 Model Architecture Details
 

--- a/Air_quality_prediction/app.py
+++ b/Air_quality_prediction/app.py
@@ -4,6 +4,11 @@ import numpy as np
 import joblib
 import torch
 import torch.nn as nn
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parent
+MODEL_PATH = PROJECT_DIR / "weights.pkl"
 
 class AstraeaNet(nn.Module):
     def __init__(self, cat_dims, num_dim):
@@ -38,9 +43,28 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 @st.cache_resource
 def load_artifacts():
-    return joblib.load("weights.pkl")
+    if not MODEL_PATH.is_file():
+        raise FileNotFoundError(
+            f"Model artifact not found at {MODEL_PATH}. "
+            "Run AQI_pred.ipynb to generate weights.pkl first."
+        )
+    return joblib.load(MODEL_PATH)
 
-data = load_artifacts()
+try:
+    data = load_artifacts()
+except FileNotFoundError as error:
+    st.error("The trained AQI model is not available yet.")
+    st.info(
+        "Open `AQI_pred.ipynb`, run all cells, and confirm that "
+        "`weights.pkl` is created in the `Air_quality_prediction` folder."
+    )
+    st.code(str(error))
+    st.stop()
+except (KeyError, OSError, ValueError) as error:
+    st.error("The AQI model artifact could not be loaded.")
+    st.info("Regenerate `weights.pkl` by running all cells in `AQI_pred.ipynb`.")
+    st.code(f"{type(error).__name__}: {error}")
+    st.stop()
 
 nn_model = data["model"].to(DEVICE)
 nn_model.eval()

--- a/Air_quality_prediction/requirements.txt
+++ b/Air_quality_prediction/requirements.txt
@@ -1,0 +1,9 @@
+joblib>=1.3,<2
+jupyter>=1.0,<2
+kagglehub>=0.2,<1
+lightgbm>=4.0,<5
+numpy>=1.26,<3
+pandas>=2.1,<3
+scikit-learn>=1.4,<2
+streamlit>=1.35,<2
+torch>=2.2,<3


### PR DESCRIPTION
Fixes the Air Quality Predictor startup failure caused by the missing `weights.pkl` model artifact.

## Changes

- Added a project-relative path for loading `weights.pkl`.
- Added graceful error messages when the artifact is missing or invalid.
- Added a project-specific `requirements.txt`.
- Documented dependency installation and model generation.
- Updated the documented project structure.

## Testing

- Verified `app.py` compiles successfully.
- Verified the notebook contains valid JSON.

Fixes: #2317 