### PR TITLE
fix: make Cyberbullying Classification dashboard reproducible

### DIFF
--- a/Cyberbullying Classification/README.md
+++ b/Cyberbullying Classification/README.md
@@ -1,28 +1,37 @@
 # Cyberbullying Classification
 
 ## Overview
-The goal is to analyze tweets to classify them into categories of cyberbullying and non-cyberbullying using NLP techniques and machine learning models.
+
+This project classifies text into age, ethnicity, gender, religion, other cyberbullying, or non-cyberbullying categories. It includes a reproducible ensemble-training script and a Streamlit dashboard.
 
 ## Dataset
-The dataset contains over 47,000 tweets labeled into six categories: Age, Ethnicity, Gender, Religion, Other type of cyberbullying, and Not cyberbullying.
 
-Link to the dataset: [Cyberbullying Classification Dataset](https://www.kaggle.com/datasets/andrewmvd/cyberbullying-classification/data)
+The training script downloads the [Cyberbullying Classification dataset](https://www.kaggle.com/datasets/andrewmvd/cyberbullying-classification) through KaggleHub. It contains more than 47,000 labelled tweets across six categories.
 
+## Model
 
-## Models Used
+The classifier is a hard-voting ensemble of logistic regression, multinomial naive Bayes, and random forest models. Text is transformed using TF-IDF word and bigram features.
 
-1. Logistic Regression
-2. Naive Bayes
-3. Random Forest Classifier
-4. Voting Classifier (Ensemble Model): Combines predictions from the above models using a majority voting scheme.
+## Setup
 
-## How to run dashboard?
+From the `Cyberbullying Classification` directory, install the dependencies:
 
-- Run all cells in training notebook to train and save model weights
-- Run
+```bash
+python -m pip install -r requirements.txt
+```
+
+Generate the model artifacts:
+
+```bash
+python train_model.py
+```
+
+The command downloads the dataset and creates `models/Voting.pkl` and `models/tfidf.pkl`. These generated artifacts are ignored by the repository and must be created locally.
+
+Run the dashboard:
+
 ```bash
 streamlit run app.py
 ```
 
-## Contribution
-Contributions are welcome! Feel free to submit issues, feature requests, or pull requests to improve the system.
+If either artifact is missing or invalid, the dashboard shows recovery instructions instead of crashing during startup.

--- a/Cyberbullying Classification/app.py
+++ b/Cyberbullying Classification/app.py
@@ -1,33 +1,54 @@
-import streamlit as st
+from pathlib import Path
+
 import joblib
+import streamlit as st
+
 from src.Predict import predict
 
 
-st.set_page_config("Text Classifier" , layout = "wide")
+PROJECT_DIR = Path(__file__).resolve().parent
+MODEL_DIR = PROJECT_DIR / "models"
+MODEL_PATH = MODEL_DIR / "Voting.pkl"
+VECTORIZER_PATH = MODEL_DIR / "tfidf.pkl"
 
-st.header("Cyber Bullying Classifier")
 
 @st.cache_resource
-def load_model():
-
-    model = joblib.load("./models/Voting.pkl")
-
-    return model
-
-model = load_model()
-with st.container():
-    text = st.text_input("Enter a sentence to classify")
+def load_artifacts():
+    missing = [path.name for path in (MODEL_PATH, VECTORIZER_PATH) if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(f"Missing model artifacts: {', '.join(missing)}")
+    return joblib.load(MODEL_PATH), joblib.load(VECTORIZER_PATH)
 
 
-    if st.button("Submit"):
+st.set_page_config(page_title="Cyberbullying Classifier", layout="wide")
+st.header("Cyberbullying Classifier")
 
-        if text is not None:
-            ans_df = predict(model , [text])
-            with st.container(border= True,horizontal_alignment="center"):
-                if ans_df['type'][0] != "not_cyberbullying":
-                    st.error(f"predicted type : {ans_df['type'][0]}")
-                else:
-                    st.success(f"predicted type : {ans_df['type'][0]}")
+try:
+    model, vectorizer = load_artifacts()
+except FileNotFoundError as error:
+    st.error("The trained cyberbullying model is not available yet.")
+    st.info("Generate the required artifacts, then restart this dashboard.")
+    st.code("python train_model.py", language="bash")
+    st.code(str(error))
+    st.stop()
+except (EOFError, OSError, ValueError) as error:
+    st.error("The saved model artifacts are invalid or incompatible.")
+    st.info("Regenerate them by running `python train_model.py`.")
+    st.code(f"{type(error).__name__}: {error}")
+    st.stop()
 
+text = st.text_area(
+    "Enter text to classify",
+    placeholder="Enter a tweet or sentence...",
+)
 
-        
+if st.button("Classify", type="primary"):
+    if not text.strip():
+        st.warning("Enter some text before running classification.")
+    else:
+        result = predict(model, vectorizer, [text]).iloc[0]
+        label = result["type"]
+        if label == "not_cyberbullying":
+            st.success(f"Predicted type: {label}")
+        else:
+            st.error(f"Predicted type: {label}")

--- a/Cyberbullying Classification/requirements.txt
+++ b/Cyberbullying Classification/requirements.txt
@@ -1,0 +1,5 @@
+joblib>=1.3,<2
+kagglehub>=0.2,<1
+pandas>=2.1,<3
+scikit-learn>=1.4,<2
+streamlit>=1.35,<2

--- a/Cyberbullying Classification/src/Predict.py
+++ b/Cyberbullying Classification/src/Predict.py
@@ -1,22 +1,23 @@
-from src.preprocess import pre_processing_custom
-import pickle
 import pandas as pd
-import joblib
 
-tfidf = joblib.load("./models/tfidf.pkl")
 
-cyberbullying_type = ['not_cyberbullying', 'gender', 'religion', 'age', 'ethnicity']
+CYBERBULLYING_TYPES = [
+    "not_cyberbullying",
+    "gender",
+    "religion",
+    "age",
+    "ethnicity",
+    "other_cyberbullying",
+]
 
 # Defing our custom prediction function
-def predict(model, texts):
-    clean_texts = [pre_processing_custom(text) for text in texts]
-    text_data = tfidf.transform(clean_texts)
+def predict(model, vectorizer, texts):
+    """Classify texts using explicitly supplied, cached model artifacts."""
+    text_data = vectorizer.transform(texts)
     prediction = model.predict(text_data)
-
-    data = []
-    for text, prediction in zip(texts, prediction):
-        data.append((text, prediction))
-
-    df = pd.DataFrame(data, columns = ['text','type'])
-    df = df.replace([0,1,2,3,4], cyberbullying_type)
-    return df
+    result = pd.DataFrame({"text": texts, "type": prediction})
+    if result["type"].dtype.kind in "iu":
+        result["type"] = result["type"].replace(
+            dict(enumerate(CYBERBULLYING_TYPES))
+        )
+    return result

--- a/Cyberbullying Classification/train_model.py
+++ b/Cyberbullying Classification/train_model.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import joblib
+import kagglehub
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier, VotingClassifier
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+from sklearn.naive_bayes import MultinomialNB
+
+
+PROJECT_DIR = Path(__file__).resolve().parent
+MODEL_DIR = PROJECT_DIR / "models"
+DATASET_HANDLE = "andrewmvd/cyberbullying-classification"
+RANDOM_STATE = 42
+
+
+def find_dataset(download_dir):
+    candidates = list(Path(download_dir).rglob("*.csv"))
+    if not candidates:
+        raise FileNotFoundError("KaggleHub downloaded no CSV dataset file")
+    return candidates[0]
+
+
+def main():
+    download_dir = kagglehub.dataset_download(DATASET_HANDLE)
+    dataset_path = find_dataset(download_dir)
+    data = pd.read_csv(dataset_path).dropna(
+        subset=["tweet_text", "cyberbullying_type"]
+    )
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        data["tweet_text"].astype(str),
+        data["cyberbullying_type"].astype(str),
+        test_size=0.2,
+        random_state=RANDOM_STATE,
+        stratify=data["cyberbullying_type"],
+    )
+
+    vectorizer = TfidfVectorizer(
+        lowercase=True,
+        stop_words="english",
+        ngram_range=(1, 2),
+        min_df=2,
+        max_features=20_000,
+        sublinear_tf=True,
+    )
+    X_train_tfidf = vectorizer.fit_transform(X_train)
+    X_test_tfidf = vectorizer.transform(X_test)
+
+    model = VotingClassifier(
+        estimators=[
+            ("logistic_regression", LogisticRegression(max_iter=1_000)),
+            ("naive_bayes", MultinomialNB()),
+            (
+                "random_forest",
+                RandomForestClassifier(
+                    n_estimators=100,
+                    random_state=RANDOM_STATE,
+                    n_jobs=-1,
+                ),
+            ),
+        ],
+        voting="hard",
+    )
+    model.fit(X_train_tfidf, y_train)
+
+    predictions = model.predict(X_test_tfidf)
+    print(f"Validation accuracy: {accuracy_score(y_test, predictions):.3f}")
+
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, MODEL_DIR / "Voting.pkl")
+    joblib.dump(vectorizer, MODEL_DIR / "tfidf.pkl")
+    print(f"Saved model artifacts to {MODEL_DIR}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes the Cyberbullying Classification dashboard, which previously crashed because `Voting.pkl` and `tfidf.pkl` were missing.

- Added `train_model.py` to download the Kaggle dataset and generate both artifacts.
- Added `requirements.txt`.
- Updated `app.py` with portable paths, graceful errors and empty-input validation.
- Updated `Predict.py` to use explicitly loaded artifacts.
- Updated README with complete setup instructions.
- Achieved 83.5% validation accuracy and verified the Streamlit prediction flow.

Fixes: #2321 